### PR TITLE
Use negative start operator as operator on left node

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -83,6 +83,7 @@
  {
    var implicit = '<implicit>';
    var wildcard = '*';
+   var negativeOps = ['NOT', '!'];
  }
 
 Start
@@ -106,8 +107,17 @@ Node
     }
   / start:OperatorExpr? left:GroupExpr positiveOp:PositiveOperatorExpr? negativeOp:NegativeOperatorExpr? right:Node*
     {
-      let node = { left, start, type: 'node' };
+      let node = { left, type: 'node' };
       let rightNode = null;
+
+      if (negativeOps.includes(start)) {
+        node.left = {
+          operator: start,
+          left
+        }
+      } else {
+        node.start = start;
+      }
 
       if (right.length > 0) {
         if (right[0].right) {

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -151,8 +151,17 @@ function peg$parse(input, options) {
             return { operator };
           },
       peg$c3 = function(start, left, positiveOp, negativeOp, right) {
-            let node = { left, start, type: 'node' };
+            let node = { left, type: 'node' };
             let rightNode = null;
+
+            if (negativeOps.includes(start)) {
+              node.left = {
+                operator: start,
+                left
+              }
+            } else {
+              node.start = start;
+            }
 
             if (right.length > 0) {
               if (right[0].right) {
@@ -2565,6 +2574,7 @@ function peg$parse(input, options) {
 
      var implicit = '<implicit>';
      var wildcard = '*';
+     var negativeOps = ['NOT', '!'];
    
 
   peg$result = peg$startRuleFunction();

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -2,6 +2,7 @@
 
 var implicit = '<implicit>';
 var wildcard = '*';
+var negativeOps = ['NOT', '!'];
 
 module.exports = function toString(ast) {
   if (!ast) {
@@ -34,12 +35,18 @@ module.exports = function toString(ast) {
   }
 
   if (ast.operator) {
-    if (ast.left) {
-      result += ' ';
-    }
+    var isNegativeOp = negativeOps.indexOf(ast.operator) !== -1;
 
-    if (ast.operator !== implicit) {
-      result += ast.operator;
+    if (ast.left && !ast.type && isNegativeOp) {
+      result = ast.operator + ' ' + result;
+    } else {
+      if (ast.left) {
+        result += ' ';
+      }
+
+      if (ast.operator !== implicit) {
+        result += ast.operator;
+      }
     }
   }
 

--- a/test/queryParserExample.test.js
+++ b/test/queryParserExample.test.js
@@ -226,9 +226,9 @@ describe('Lucene Query syntax documentation examples', () => {
   it('parses example: NOT "jakarta apache"', () => {
     const results = lucene.parse('NOT "jakarta apache"');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
-    expect(results.start).to.equal('NOT');
+    expect(results.left.left.field).to.equal('<implicit>');
+    expect(results.left.left.term).to.equal('jakarta apache');
+    expect(results.left.operator).to.equal('NOT');
     expect(results.right).to.equal(undefined);
     expect(results.operator).to.equal(undefined);
   });
@@ -288,13 +288,14 @@ describe('Lucene Query syntax documentation examples', () => {
     const results = lucene.parse('NOT (java OR python) AND android');
     const leftNode = results.left;
 
-    expect(results.start).to.equal('NOT');
+    // expect(results.start).to.equal('NOT');
 
-    expect(leftNode.left.field).to.equal('<implicit>');
-    expect(leftNode.left.term).to.equal('java');
-    expect(leftNode.operator).to.equal('OR');
-    expect(leftNode.right.field).to.equal('<implicit>');
-    expect(leftNode.right.term).to.equal('python');
+    expect(leftNode.left.left.field).to.equal('<implicit>');
+    expect(leftNode.left.left.term).to.equal('java');
+    expect(leftNode.operator).to.equal('NOT');
+    expect(leftNode.left.operator).to.equal('OR');
+    expect(leftNode.left.right.field).to.equal('<implicit>');
+    expect(leftNode.left.right.term).to.equal('python');
 
     expect(results.operator).to.equal('AND');
     expect(results.right.field).to.equal('<implicit>');


### PR DESCRIPTION
### Make a negative starting operator apply to the left node. 
The current behavior when parsing an expression that starts with a negative operator is to not associate the operator with the left node of the expression, but rather to treat it separately as a `start` operator. E.g.
```js
lucene.parse('NOT foo:bar AND name:bro');

/**
{
  left: {
    field: 'foo',
    fieldLocation: { start: [Object], end: [Object] },
    similarity: null,
    boost: null,
    prefix: null,
    term: 'bar',
    quoted: false,
    regex: false,
    type: 'term',
    termLocation: { start: [Object], end: [Object] }
  },
  start: 'NOT',
  type: 'node',
  right: {
    field: 'name',
    fieldLocation: { start: [Object], end: [Object] },
    similarity: null,
    boost: null,
    prefix: null,
    term: 'bro',
    quoted: false,
    regex: false,
    type: 'term',
    termLocation: { start: [Object], end: [Object] }
  },
  operator: 'AND'
}
 */
```

We want that `NOT` operator to apply to the `left` expression to read _"I want results that don't match `foo:bar` and have `name:bro`"_. So, with this change, the result would look like this. 

```js
/**
lucene.parse('NOT foo:bar AND name:bro');

{
  left: {
    operator: "NOT",
    left: {
      field: "foo",
      fieldLocation: { start: [Object], end: [Object] },
      similarity: null,
      boost: null,
      prefix: null,
      term: "bar",
      quoted: false,
      regex: false,
      type: "term",
      termLocation: { start: [Object], end: [Object] },
    },
  },
  type: "node",
  right: {
    field: "name",
    fieldLocation: { start: [Object], end: [Object] },
    similarity: null,
    boost: null,
    prefix: null,
    term: "bro",
    quoted: false,
    regex: false,
    type: "term",
    termLocation: { start: [Object], end: [Object] },
  },
  operator: "AND",
}

 */
```

*Note*: This change only applies to negative operators because in our use case we only care about the `start` operator when it's a negative operator.