### PR TITLE
Enforcing boolean operator precedence and allow '\' in phrases

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,14 @@
 module.exports = {
-  parser: 'babel-eslint',
-  extends: 'eslint:recommended',
+  parser: "babel-eslint",
+  extends: "eslint:recommended",
   env: {
-    node: true
+    node: true,
   },
   rules: {
-    indent: ['error', 2],
-    'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
-    semi: ['error', 'always'],
-    'no-useless-escape': 0
-  }
+    indent: ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    quotes: ["error", "single"],
+    semi: ["error", "always"],
+    "no-useless-escape": 0,
+  },
 };

--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -83,7 +83,6 @@
  {
    var implicit = '<implicit>';
    var wildcard = '*';
-   var negativeOps = ['NOT', '!'];
 
    var leftAssociative = (originalLeft, operator, rest) =>
      rest.reduce((left, right) => ({ left, operator, right }), originalLeft);
@@ -92,7 +91,6 @@
 Start
   = _* node:ClauseOr
     {
-      //return node;
       if (!node.operator) {
         return {
           left: node,
@@ -163,77 +161,8 @@ PrimaryClause
     return left;
   }
 
-
-Node
-  = operator:OperatorExpr EOF
-  {
-    return { operator };
-  }
-  / operator:OperatorExpr? _* left:ClauseOr _* EOF
-  {
-    return { ...left, type: 'node' };
-  }
-  // start:OperatorExpr? left:GroupExpr positiveOp:PositiveOperatorExpr? negativeOp:NegativeOperatorExpr? right:Node*
-  // {
-  //   let node = { left, type: 'node' };
-  //   let rightNode = null;
-
-  //   if (negativeOps.includes(start)) {
-  //     node.left = {
-  //       operator: start,
-  //       left
-  //     }
-  //   } else {
-  //     node.start = start;
-  //   }
-
-  //   if (right.length > 0) {
-  //     if (right[0].right) {
-  //       rightNode = right[0];
-  //     } else {
-  //       rightNode = right[0].left;
-  //     }
-
-  //     if (positiveOp && negativeOp) {
-  //       // AND NOT or OR NOT
-  //       // In this situation we have a nested group
-  //       // node.right = { operator: negativeOp, left: rightNode}
-  //       node.right = {
-  //         operator: negativeOp,
-  //         left: rightNode
-  //       };
-  //     } else {
-  //       node.right = rightNode;
-  //     }
-
-  //     node.operator = positiveOp || negativeOp || implicit;
-  //   }
-
-  //   return node;
-  // }
-  // operator:OperatorExpr right:Node
-  // {
-  //   return right;
-  // }
-
-GroupExpr
-  = fieldExp:FieldExpr _*
-    {
-      return fieldExp;
-    }
-  / ParenExpr
-
-ParenExpr
-  = "(" _* node:Node* ")" _*
-    {
-      // I need to better understand this area
-      node[0].parenthesized = true;
-      node[0].type = 'node';
-      return node[0];
-    }
-
 FieldExpr
-  = prefix:PrefixOperatorExpr? fieldname:FieldName range:SingleRangeOperatorExpr
+  = prefix:PrefixOperator? fieldname:FieldName range:SingleRangeOperatorExpr
     {
       range.field = fieldname.name;
       range.fieldLocation = fieldname.location;
@@ -242,7 +171,7 @@ FieldExpr
 
       return range;
     }
-  / prefix:PrefixOperatorExpr? fieldname:FieldName? range:RangeOperatorExpr
+  / prefix:PrefixOperator? fieldname:FieldName? range:RangeOperatorExpr
     {
       range.field = fieldname == null || fieldname.name == '' ? implicit : fieldname.name;
       range.fieldLocation = fieldname == null || fieldname.name == '' ? null : fieldname.location;
@@ -251,7 +180,7 @@ FieldExpr
 
       return range;
     }
-  / prefix:PrefixOperatorExpr? fieldname:FieldName node:PrimaryClause
+  / prefix:PrefixOperator? fieldname:FieldName node:PrimaryClause
     {
         node.field = fieldname.name;
         node.fieldLocation = fieldname.location;
@@ -260,7 +189,7 @@ FieldExpr
 
         return node;
     }
-  / prefix:PrefixOperatorExpr? fieldname:FieldName? term:Term
+  / prefix:PrefixOperator? fieldname:FieldName? term:Term
     {
       let fieldexp = {
         field: fieldname == null || fieldname.name == '' ? implicit : fieldname.name,
@@ -301,7 +230,7 @@ Term
 
       return result;
     }
-  / prefix:PrefixOperatorExpr? term:RegexTerm _*
+  / prefix:PrefixOperator? term:RegexTerm _*
     {
       let result = {
         term: term,
@@ -315,7 +244,7 @@ Term
 
       return result;
     }
-  / prefix:PrefixOperatorExpr? term:UnquotedTerm similarity:FuzzyModifier? boost:BoostModifier? _*
+  / prefix:PrefixOperator? term:UnquotedTerm similarity:FuzzyModifier? boost:BoostModifier? _*
     {
       return {
         similarity,
@@ -457,67 +386,6 @@ SingleRangeOperator
   / '<='
   / '>'
   / '<'
-
-SingleExpr
-  = _* operator:Operator _+
-    {
-      return operator;
-    }
-  / _* operator:Operator EOF
-    {
-      return operator;
-    }
-
-OperatorExpr
-  = _* operator:Operator _+
-    {
-      return operator;
-    }
-  / _* operator:Operator EOF
-    {
-      return operator;
-    }
-
-PositiveOperatorExpr
-  = _* operator:PositiveOperator _+
-    {
-      return operator;
-    }
-  / _* operator:PositiveOperator EOF
-    {
-      return operator;
-    }
-
-NegativeOperatorExpr
-  = _* operator:NegativeOperator _+
-    {
-      return operator;
-    }
-  / _* operator:NegativeOperator EOF
-    {
-      return operator;
-    }
-
-
-PositiveOperator
-  = 'OR'
-  / 'AND'
-  / '||'
-  / '&&'
-
-NegativeOperator
-  = 'NOT'
-  / '!'
-
-Operator
-  = PositiveOperator
-  / NegativeOperator
-
-PrefixOperatorExpr
-  = _* operator:PrefixOperator
-    {
-      return operator;
-    }
 
 PrefixOperator
   = '+'

--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -86,28 +86,29 @@
 
    var leftAssociative = (originalLeft, operator, rest) =>
      rest.reduce((left, right) => ({ left, operator, right }), originalLeft);
+
+   var wrapInNode = (node, operator = null) => {
+     if (!node.operator) {
+       return {
+         left: node,
+         type: 'node',
+       };
+     }
+
+     return { ...node, type: 'node' };
+   }
  }
 
 Start
-  = _* node:ClauseOr
-    {
-      if (!node.operator) {
-        return {
-          left: node,
-          type: 'node',
-        }
-      }
+  = operator:BooleanOperator _* EOF { return { operator }; }
+  /  BinaryOperator _* node:ClauseOr { return wrapInNode(node); }
+  / _* node:ClauseOr { return wrapInNode(node); }
+  / _* { return {}; }
+  / EOF { return {}; }
 
-      return { ...node, type: 'node' };
-    }
-  / _*
-    {
-      return {};
-    }
-  / EOF
-    {
-      return {};
-    }
+BooleanOperator = BinaryOperator / UnaryOperator
+BinaryOperator = LogicalAnd / LogicalOr;
+UnaryOperator = LogicalNot
 
 LogicalAnd
   = 'AND'
@@ -294,7 +295,12 @@ RegexTerm
 
 DoubleStringCharacter
   = !('"' / "\\") char:. { return char; }
+  / EscapedChar
   / "\\" sequence:EscapeSequence { return '\\' + sequence; }
+
+EscapedChar
+  = "\\" char:[^\"\\] { return '\\' + char; }
+  / "\\" char:[^\"\\\?\*] { return '\\' + char; }
 
 RegexCharacter
   = !('/' / "\\") char:. { return char; }

--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -84,12 +84,23 @@
    var implicit = '<implicit>';
    var wildcard = '*';
    var negativeOps = ['NOT', '!'];
+
+   var leftAssociative = (originalLeft, operator, rest) =>
+     rest.reduce((left, right) => ({ left, operator, right }), originalLeft);
  }
 
 Start
-  = _* node:Node+
+  = _* node:ClauseOr
     {
-      return node[0];
+      //return node;
+      if (!node.operator) {
+        return {
+          left: node,
+          type: 'node',
+        }
+      }
+
+      return { ...node, type: 'node' };
     }
   / _*
     {
@@ -100,53 +111,110 @@ Start
       return {};
     }
 
+LogicalAnd
+  = 'AND'
+  / '&&'
+
+LogicalOr
+  = 'OR'
+  / '||'
+
+LogicalNot
+  = 'NOT'
+  / '!'
+
+ClauseOr
+  = _* left:ClauseAnd _* operator:LogicalOr _* rest:ClauseOr*
+  {
+    return leftAssociative(left, operator || implicit, rest);
+  }
+  / _* left:ClauseAnd _* rest:ClauseOr*
+  {
+    return leftAssociative(left, implicit, rest);
+  }
+  / ClauseAnd
+
+ClauseAnd
+  = _* left:ClauseNot _* operator:LogicalAnd _+ right:ClauseAnd _*
+  {
+    return { left, operator, right, type: 'node'}
+  }
+  / ClauseNot
+
+ClauseNot
+  = _* operator:LogicalNot _+ left:PrimaryClause _*
+  {
+    return { left, operator, right: null, type: 'node'};
+  }
+  / PrimaryClause
+
+
+PrimaryClause
+  = _* '(' _* left:ClauseOr _* ')'
+  {
+    if (left && left.left) {
+      return {...left, type: 'node', parenthesized: true };
+    }
+
+    return { left, type: 'node', parenthesized: true };
+    }
+  / left:FieldExpr
+  {
+    return left;
+  }
+
+
 Node
   = operator:OperatorExpr EOF
-    {
-      return { operator };
-    }
-  / start:OperatorExpr? left:GroupExpr positiveOp:PositiveOperatorExpr? negativeOp:NegativeOperatorExpr? right:Node*
-    {
-      let node = { left, type: 'node' };
-      let rightNode = null;
+  {
+    return { operator };
+  }
+  / operator:OperatorExpr? _* left:ClauseOr _* EOF
+  {
+    return { ...left, type: 'node' };
+  }
+  // start:OperatorExpr? left:GroupExpr positiveOp:PositiveOperatorExpr? negativeOp:NegativeOperatorExpr? right:Node*
+  // {
+  //   let node = { left, type: 'node' };
+  //   let rightNode = null;
 
-      if (negativeOps.includes(start)) {
-        node.left = {
-          operator: start,
-          left
-        }
-      } else {
-        node.start = start;
-      }
+  //   if (negativeOps.includes(start)) {
+  //     node.left = {
+  //       operator: start,
+  //       left
+  //     }
+  //   } else {
+  //     node.start = start;
+  //   }
 
-      if (right.length > 0) {
-        if (right[0].right) {
-          rightNode = right[0];
-        } else {
-          rightNode = right[0].left;
-        }
+  //   if (right.length > 0) {
+  //     if (right[0].right) {
+  //       rightNode = right[0];
+  //     } else {
+  //       rightNode = right[0].left;
+  //     }
 
-        if (positiveOp && negativeOp) {
-          // AND NOT or OR NOT
-          // In this situation we have a nested group
-          // node.right = { operator: negativeOp, left: rightNode}
-          node.right = {
-            operator: negativeOp,
-            left: rightNode
-          };
-        } else {
-          node.right = rightNode;
-        }
+  //     if (positiveOp && negativeOp) {
+  //       // AND NOT or OR NOT
+  //       // In this situation we have a nested group
+  //       // node.right = { operator: negativeOp, left: rightNode}
+  //       node.right = {
+  //         operator: negativeOp,
+  //         left: rightNode
+  //       };
+  //     } else {
+  //       node.right = rightNode;
+  //     }
 
-        node.operator = positiveOp || negativeOp || implicit;
-      }
+  //     node.operator = positiveOp || negativeOp || implicit;
+  //   }
 
-      return node;
-    }
-  / operator:OperatorExpr right:Node
-    {
-      return right;
-    }
+  //   return node;
+  // }
+  // operator:OperatorExpr right:Node
+  // {
+  //   return right;
+  // }
 
 GroupExpr
   = fieldExp:FieldExpr _*
@@ -156,7 +224,7 @@ GroupExpr
   / ParenExpr
 
 ParenExpr
-  = "(" _* node:Node+ ")" _*
+  = "(" _* node:Node* ")" _*
     {
       // I need to better understand this area
       node[0].parenthesized = true;
@@ -183,7 +251,7 @@ FieldExpr
 
       return range;
     }
-  / prefix:PrefixOperatorExpr? fieldname:FieldName node:ParenExpr
+  / prefix:PrefixOperatorExpr? fieldname:FieldName node:PrimaryClause
     {
         node.field = fieldname.name;
         node.fieldLocation = fieldname.location;

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -142,68 +142,73 @@ function peg$parse(input, options) {
       peg$startRuleFunction  = peg$parseStart,
 
       peg$c0 = function(node) {
-            return node[0];
+            //return node;
+            if (!node.operator) {
+              return {
+                left: node,
+                type: 'node',
+              }
+            }
+
+            return { ...node, type: 'node' };
           },
       peg$c1 = function() {
             return {};
           },
-      peg$c2 = function(operator) {
-            return { operator };
+      peg$c2 = "AND",
+      peg$c3 = peg$literalExpectation("AND", false),
+      peg$c4 = "&&",
+      peg$c5 = peg$literalExpectation("&&", false),
+      peg$c6 = "OR",
+      peg$c7 = peg$literalExpectation("OR", false),
+      peg$c8 = "||",
+      peg$c9 = peg$literalExpectation("||", false),
+      peg$c10 = "NOT",
+      peg$c11 = peg$literalExpectation("NOT", false),
+      peg$c12 = "!",
+      peg$c13 = peg$literalExpectation("!", false),
+      peg$c14 = function(left, operator, rest) {
+          return leftAssociative(left, operator || implicit, rest);
+        },
+      peg$c15 = function(left, rest) {
+          return leftAssociative(left, implicit, rest);
+        },
+      peg$c16 = function(left, operator, right) {
+          return { left, operator, right, type: 'node'}
+        },
+      peg$c17 = function(operator, left) {
+          return { left, operator, right: null, type: 'node'};
+        },
+      peg$c18 = "(",
+      peg$c19 = peg$literalExpectation("(", false),
+      peg$c20 = ")",
+      peg$c21 = peg$literalExpectation(")", false),
+      peg$c22 = function(left) {
+          if (left && left.left) {
+            return {...left, type: 'node', parenthesized: true };
+          }
+
+          return { left, type: 'node', parenthesized: true };
           },
-      peg$c3 = function(start, left, positiveOp, negativeOp, right) {
-            let node = { left, type: 'node' };
-            let rightNode = null;
-
-            if (negativeOps.includes(start)) {
-              node.left = {
-                operator: start,
-                left
-              }
-            } else {
-              node.start = start;
-            }
-
-            if (right.length > 0) {
-              if (right[0].right) {
-                rightNode = right[0];
-              } else {
-                rightNode = right[0].left;
-              }
-
-              if (positiveOp && negativeOp) {
-                // AND NOT or OR NOT
-                // In this situation we have a nested group
-                // node.right = { operator: negativeOp, left: rightNode}
-                node.right = {
-                  operator: negativeOp,
-                  left: rightNode
-                };
-              } else {
-                node.right = rightNode;
-              }
-
-              node.operator = positiveOp || negativeOp || implicit;
-            }
-
-            return node;
-          },
-      peg$c4 = function(operator, right) {
-            return right;
-          },
-      peg$c5 = function(fieldExp) {
+      peg$c23 = function(left) {
+          return left;
+        },
+      peg$c24 = function(operator) {
+          return { operator };
+        },
+      peg$c25 = function(operator, left) {
+          return { ...left, type: 'node' };
+        },
+      peg$c26 = function(fieldExp) {
             return fieldExp;
           },
-      peg$c6 = "(",
-      peg$c7 = peg$literalExpectation("(", false),
-      peg$c8 = ")",
-      peg$c9 = peg$literalExpectation(")", false),
-      peg$c10 = function(node) {
+      peg$c27 = function(node) {
             // I need to better understand this area
             node[0].parenthesized = true;
             node[0].type = 'node';
             return node[0];
           },
-      peg$c11 = function(prefix, fieldname, range) {
+      peg$c28 = function(prefix, fieldname, range) {
             range.field = fieldname.name;
             range.fieldLocation = fieldname.location;
 
@@ -211,7 +216,7 @@ function peg$parse(input, options) {
 
             return range;
           },
-      peg$c12 = function(prefix, fieldname, range) {
+      peg$c29 = function(prefix, fieldname, range) {
             range.field = fieldname == null || fieldname.name == '' ? implicit : fieldname.name;
             range.fieldLocation = fieldname == null || fieldname.name == '' ? null : fieldname.location;
 
@@ -219,7 +224,7 @@ function peg$parse(input, options) {
 
             return range;
           },
-      peg$c13 = function(prefix, fieldname, node) {
+      peg$c30 = function(prefix, fieldname, node) {
               node.field = fieldname.name;
               node.fieldLocation = fieldname.location;
 
@@ -227,7 +232,7 @@ function peg$parse(input, options) {
 
               return node;
           },
-      peg$c14 = function(prefix, fieldname, term) {
+      peg$c31 = function(prefix, fieldname, term) {
             let fieldexp = {
               field: fieldname == null || fieldname.name == '' ? implicit : fieldname.name,
               fieldLocation: fieldname == null || fieldname.name == '' ? null : fieldname.location,
@@ -241,15 +246,15 @@ function peg$parse(input, options) {
 
             return fieldexp;
           },
-      peg$c15 = /^[:]/,
-      peg$c16 = peg$classExpectation([":"], false, false),
-      peg$c17 = function(fieldname) {
+      peg$c32 = /^[:]/,
+      peg$c33 = peg$classExpectation([":"], false, false),
+      peg$c34 = function(fieldname) {
             return {
               name: fieldname.value,
               location: fieldname.location
             };
           },
-      peg$c18 = function(term, proximity, boost) {
+      peg$c35 = function(term, proximity, boost) {
             let result = {
               term,
               proximity,
@@ -263,7 +268,7 @@ function peg$parse(input, options) {
 
             return result;
           },
-      peg$c19 = function(prefix, term) {
+      peg$c36 = function(prefix, term) {
             let result = {
               term: term,
               quoted: false,
@@ -276,7 +281,7 @@ function peg$parse(input, options) {
 
             return result;
           },
-      peg$c20 = function(prefix, term, similarity, boost) {
+      peg$c37 = function(prefix, term, similarity, boost) {
             return {
               similarity,
               boost,
@@ -288,69 +293,69 @@ function peg$parse(input, options) {
               termLocation: location()
             };
           },
-      peg$c21 = "\\",
-      peg$c22 = peg$literalExpectation("\\", false),
-      peg$c23 = function(sequence) { return '\\' + sequence; },
-      peg$c24 = ".",
-      peg$c25 = peg$literalExpectation(".", false),
-      peg$c26 = /^[^ \t\r\n\f{}()\/\^~[\]]/,
-      peg$c27 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "/", "^", "~", "[", "]"], true, false),
-      peg$c28 = function(term) {
+      peg$c38 = "\\",
+      peg$c39 = peg$literalExpectation("\\", false),
+      peg$c40 = function(sequence) { return '\\' + sequence; },
+      peg$c41 = ".",
+      peg$c42 = peg$literalExpectation(".", false),
+      peg$c43 = /^[^ \t\r\n\f{}()\/\^~[\]]/,
+      peg$c44 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "/", "^", "~", "[", "]"], true, false),
+      peg$c45 = function(term) {
             return {
               value: term.join(''),
               location: location()
             };
           },
-      peg$c29 = function(term) {
+      peg$c46 = function(term) {
             return {
               value: term.join(''),
               location: location(),
             };
           },
-      peg$c30 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
-      peg$c31 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
-      peg$c32 = "\"",
-      peg$c33 = peg$literalExpectation("\"", false),
-      peg$c34 = function(chars) { return chars.join(''); },
-      peg$c35 = "/",
-      peg$c36 = peg$literalExpectation("/", false),
-      peg$c37 = function(chars) { return chars.join('') },
-      peg$c38 = peg$anyExpectation(),
-      peg$c39 = function(char) { return char; },
-      peg$c40 = "~",
-      peg$c41 = peg$literalExpectation("~", false),
-      peg$c42 = function(proximity) {
+      peg$c47 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
+      peg$c48 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
+      peg$c49 = "\"",
+      peg$c50 = peg$literalExpectation("\"", false),
+      peg$c51 = function(chars) { return chars.join(''); },
+      peg$c52 = "/",
+      peg$c53 = peg$literalExpectation("/", false),
+      peg$c54 = function(chars) { return chars.join('') },
+      peg$c55 = peg$anyExpectation(),
+      peg$c56 = function(char) { return char; },
+      peg$c57 = "~",
+      peg$c58 = peg$literalExpectation("~", false),
+      peg$c59 = function(proximity) {
             return proximity;
           },
-      peg$c43 = "^",
-      peg$c44 = peg$literalExpectation("^", false),
-      peg$c45 = function(boost) {
+      peg$c60 = "^",
+      peg$c61 = peg$literalExpectation("^", false),
+      peg$c62 = function(boost) {
             return boost;
           },
-      peg$c46 = function(fuzziness) {
+      peg$c63 = function(fuzziness) {
             return fuzziness == '' || fuzziness == null ? 0.5 : fuzziness;
           },
-      peg$c47 = "0.",
-      peg$c48 = peg$literalExpectation("0.", false),
-      peg$c49 = /^[0-9]/,
-      peg$c50 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c51 = function(val) {
+      peg$c64 = "0.",
+      peg$c65 = peg$literalExpectation("0.", false),
+      peg$c66 = /^[0-9]/,
+      peg$c67 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c68 = function(val) {
             return parseFloat("0." + val.join(''));
           },
-      peg$c52 = function(val) {
+      peg$c69 = function(val) {
             return parseInt(val.join(''));
           },
-      peg$c53 = "[",
-      peg$c54 = peg$literalExpectation("[", false),
-      peg$c55 = "{",
-      peg$c56 = peg$literalExpectation("{", false),
-      peg$c57 = "]",
-      peg$c58 = peg$literalExpectation("]", false),
-      peg$c59 = "}",
-      peg$c60 = peg$literalExpectation("}", false),
-      peg$c61 = "TO",
-      peg$c62 = peg$literalExpectation("TO", false),
-      peg$c63 = function(rangeOpen, termMin, termMax, rangeClose) {
+      peg$c70 = "[",
+      peg$c71 = peg$literalExpectation("[", false),
+      peg$c72 = "{",
+      peg$c73 = peg$literalExpectation("{", false),
+      peg$c74 = "]",
+      peg$c75 = peg$literalExpectation("]", false),
+      peg$c76 = "}",
+      peg$c77 = peg$literalExpectation("}", false),
+      peg$c78 = "TO",
+      peg$c79 = peg$literalExpectation("TO", false),
+      peg$c80 = function(rangeOpen, termMin, termMax, rangeClose) {
             return {
               type: 'range',
               termMin: termMin.value,
@@ -361,7 +366,7 @@ function peg$parse(input, options) {
               maxInclusive: rangeClose === ']'
             };
           },
-      peg$c64 = function(op, term) {
+      peg$c81 = function(op, term) {
             if (op.startsWith('>')) {
               return {
                 type: 'range',
@@ -382,50 +387,38 @@ function peg$parse(input, options) {
               };
             }
           },
-      peg$c65 = ">=",
-      peg$c66 = peg$literalExpectation(">=", false),
-      peg$c67 = "<=",
-      peg$c68 = peg$literalExpectation("<=", false),
-      peg$c69 = ">",
-      peg$c70 = peg$literalExpectation(">", false),
-      peg$c71 = "<",
-      peg$c72 = peg$literalExpectation("<", false),
-      peg$c73 = function(operator) {
+      peg$c82 = ">=",
+      peg$c83 = peg$literalExpectation(">=", false),
+      peg$c84 = "<=",
+      peg$c85 = peg$literalExpectation("<=", false),
+      peg$c86 = ">",
+      peg$c87 = peg$literalExpectation(">", false),
+      peg$c88 = "<",
+      peg$c89 = peg$literalExpectation("<", false),
+      peg$c90 = function(operator) {
             return operator;
           },
-      peg$c74 = "OR",
-      peg$c75 = peg$literalExpectation("OR", false),
-      peg$c76 = "AND",
-      peg$c77 = peg$literalExpectation("AND", false),
-      peg$c78 = "||",
-      peg$c79 = peg$literalExpectation("||", false),
-      peg$c80 = "&&",
-      peg$c81 = peg$literalExpectation("&&", false),
-      peg$c82 = "NOT",
-      peg$c83 = peg$literalExpectation("NOT", false),
-      peg$c84 = "!",
-      peg$c85 = peg$literalExpectation("!", false),
-      peg$c86 = "+",
-      peg$c87 = peg$literalExpectation("+", false),
-      peg$c88 = "-",
-      peg$c89 = peg$literalExpectation("-", false),
-      peg$c90 = peg$otherExpectation("whitespace"),
-      peg$c91 = /^[ \t\r\n\f]/,
-      peg$c92 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
-      peg$c93 = "?",
-      peg$c94 = peg$literalExpectation("?", false),
-      peg$c95 = ":",
-      peg$c96 = peg$literalExpectation(":", false),
-      peg$c97 = "&",
-      peg$c98 = peg$literalExpectation("&", false),
-      peg$c99 = "|",
-      peg$c100 = peg$literalExpectation("|", false),
-      peg$c101 = "'",
-      peg$c102 = peg$literalExpectation("'", false),
-      peg$c103 = "*",
-      peg$c104 = peg$literalExpectation("*", false),
-      peg$c105 = " ",
-      peg$c106 = peg$literalExpectation(" ", false),
+      peg$c91 = "+",
+      peg$c92 = peg$literalExpectation("+", false),
+      peg$c93 = "-",
+      peg$c94 = peg$literalExpectation("-", false),
+      peg$c95 = peg$otherExpectation("whitespace"),
+      peg$c96 = /^[ \t\r\n\f]/,
+      peg$c97 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
+      peg$c98 = "?",
+      peg$c99 = peg$literalExpectation("?", false),
+      peg$c100 = ":",
+      peg$c101 = peg$literalExpectation(":", false),
+      peg$c102 = "&",
+      peg$c103 = peg$literalExpectation("&", false),
+      peg$c104 = "|",
+      peg$c105 = peg$literalExpectation("|", false),
+      peg$c106 = "'",
+      peg$c107 = peg$literalExpectation("'", false),
+      peg$c108 = "*",
+      peg$c109 = peg$literalExpectation("*", false),
+      peg$c110 = " ",
+      peg$c111 = peg$literalExpectation(" ", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -564,7 +557,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseStart() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
@@ -574,16 +567,7 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
     }
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseNode();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseNode();
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parseClauseOr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c0(s2);
@@ -623,53 +607,113 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNode() {
-    var s0, s1, s2, s3, s4, s5, s6;
+  function peg$parseLogicalAnd() {
+    var s0;
 
-    s0 = peg$currPos;
-    s1 = peg$parseOperatorExpr();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseEOF();
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c2(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    if (input.substr(peg$currPos, 3) === peg$c2) {
+      s0 = peg$c2;
+      peg$currPos += 3;
     } else {
-      peg$currPos = s0;
       s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c3); }
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseOperatorExpr();
-      if (s1 === peg$FAILED) {
-        s1 = null;
+      if (input.substr(peg$currPos, 2) === peg$c4) {
+        s0 = peg$c4;
+        peg$currPos += 2;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c5); }
       }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseGroupExpr();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parsePositiveOperatorExpr();
-          if (s3 === peg$FAILED) {
-            s3 = null;
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parseNegativeOperatorExpr();
-            if (s4 === peg$FAILED) {
-              s4 = null;
+    }
+
+    return s0;
+  }
+
+  function peg$parseLogicalOr() {
+    var s0;
+
+    if (input.substr(peg$currPos, 2) === peg$c6) {
+      s0 = peg$c6;
+      peg$currPos += 2;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c7); }
+    }
+    if (s0 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c8) {
+        s0 = peg$c8;
+        peg$currPos += 2;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseLogicalNot() {
+    var s0;
+
+    if (input.substr(peg$currPos, 3) === peg$c10) {
+      s0 = peg$c10;
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c11); }
+    }
+    if (s0 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 33) {
+        s0 = peg$c12;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseClauseOr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parse_();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parse_();
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseClauseAnd();
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$parse_();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parse_();
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseLogicalOr();
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$parse_();
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              s6 = peg$parse_();
             }
-            if (s4 !== peg$FAILED) {
-              s5 = [];
-              s6 = peg$parseNode();
-              while (s6 !== peg$FAILED) {
-                s5.push(s6);
-                s6 = peg$parseNode();
+            if (s5 !== peg$FAILED) {
+              s6 = [];
+              s7 = peg$parseClauseOr();
+              while (s7 !== peg$FAILED) {
+                s6.push(s7);
+                s7 = peg$parseClauseOr();
               }
-              if (s5 !== peg$FAILED) {
+              if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c3(s1, s2, s3, s4, s5);
+                s1 = peg$c14(s2, s4, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -691,15 +735,42 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseOperatorExpr();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parseNode();
-          if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c4(s1, s2);
-            s0 = s1;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = [];
+      s2 = peg$parse_();
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$parse_();
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseClauseAnd();
+        if (s2 !== peg$FAILED) {
+          s3 = [];
+          s4 = peg$parse_();
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parse_();
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = [];
+            s5 = peg$parseClauseOr();
+            while (s5 !== peg$FAILED) {
+              s4.push(s5);
+              s5 = peg$parseClauseOr();
+            }
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c15(s2, s4);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -708,6 +779,310 @@ function peg$parse(input, options) {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseClauseAnd();
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseClauseAnd() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parse_();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parse_();
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseClauseNot();
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$parse_();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parse_();
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseLogicalAnd();
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              while (s6 !== peg$FAILED) {
+                s5.push(s6);
+                s6 = peg$parse_();
+              }
+            } else {
+              s5 = peg$FAILED;
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseClauseAnd();
+              if (s6 !== peg$FAILED) {
+                s7 = [];
+                s8 = peg$parse_();
+                while (s8 !== peg$FAILED) {
+                  s7.push(s8);
+                  s8 = peg$parse_();
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c16(s2, s4, s6);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseClauseNot();
+    }
+
+    return s0;
+  }
+
+  function peg$parseClauseNot() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parse_();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parse_();
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseLogicalNot();
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parse_();
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsePrimaryClause();
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$parse_();
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              s6 = peg$parse_();
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c17(s2, s4);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsePrimaryClause();
+    }
+
+    return s0;
+  }
+
+  function peg$parsePrimaryClause() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parse_();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parse_();
+    }
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s2 = peg$c18;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$parse_();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parse_();
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseClauseOr();
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$parse_();
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              s6 = peg$parse_();
+            }
+            if (s5 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s6 = peg$c20;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c21); }
+              }
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c22(s4);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseFieldExpr();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c23(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNode() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parseOperatorExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseEOF();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c24(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseOperatorExpr();
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parse_();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parse_();
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseClauseOr();
+          if (s3 !== peg$FAILED) {
+            s4 = [];
+            s5 = peg$parse_();
+            while (s5 !== peg$FAILED) {
+              s4.push(s5);
+              s5 = peg$parse_();
+            }
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseEOF();
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c25(s1, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
     }
 
@@ -728,7 +1103,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s1);
+        s1 = peg$c26(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -750,11 +1125,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c6;
+      s1 = peg$c18;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c7); }
+      if (peg$silentFails === 0) { peg$fail(peg$c19); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -766,21 +1141,17 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = [];
         s4 = peg$parseNode();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseNode();
-          }
-        } else {
-          s3 = peg$FAILED;
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parseNode();
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s4 = peg$c8;
+            s4 = peg$c20;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c9); }
+            if (peg$silentFails === 0) { peg$fail(peg$c21); }
           }
           if (s4 !== peg$FAILED) {
             s5 = [];
@@ -791,7 +1162,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c10(s3);
+              s1 = peg$c27(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -831,7 +1202,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSingleRangeOperatorExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c11(s1, s2, s3);
+          s1 = peg$c28(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -860,7 +1231,7 @@ function peg$parse(input, options) {
           s3 = peg$parseRangeOperatorExpr();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c12(s1, s2, s3);
+            s1 = peg$c29(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -883,10 +1254,10 @@ function peg$parse(input, options) {
         if (s1 !== peg$FAILED) {
           s2 = peg$parseFieldName();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseParenExpr();
+            s3 = peg$parsePrimaryClause();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c13(s1, s2, s3);
+              s1 = peg$c30(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -915,7 +1286,7 @@ function peg$parse(input, options) {
               s3 = peg$parseTerm();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c14(s1, s2, s3);
+                s1 = peg$c31(s1, s2, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -942,12 +1313,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseUnquotedTerm();
     if (s1 !== peg$FAILED) {
-      if (peg$c15.test(input.charAt(peg$currPos))) {
+      if (peg$c32.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c16); }
+        if (peg$silentFails === 0) { peg$fail(peg$c33); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -958,7 +1329,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c17(s1);
+          s1 = peg$c34(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1000,7 +1371,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c18(s1, s2, s3);
+            s1 = peg$c35(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1035,7 +1406,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c19(s1, s2);
+            s1 = peg$c36(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1076,7 +1447,7 @@ function peg$parse(input, options) {
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c20(s1, s2, s3, s4);
+                  s1 = peg$c37(s1, s2, s3, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1109,17 +1480,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c21;
+      s1 = peg$c38;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c22); }
+      if (peg$silentFails === 0) { peg$fail(peg$c39); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c23(s2);
+        s1 = peg$c40(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1131,19 +1502,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c24;
+        s0 = peg$c41;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c42); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c26.test(input.charAt(peg$currPos))) {
+        if (peg$c43.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c27); }
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
         }
       }
     }
@@ -1167,7 +1538,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c28(s1);
+      s1 = peg$c45(s1);
     }
     s0 = s1;
 
@@ -1190,7 +1561,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c29(s1);
+      s1 = peg$c46(s1);
     }
     s0 = s1;
 
@@ -1202,17 +1573,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c21;
+      s1 = peg$c38;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c22); }
+      if (peg$silentFails === 0) { peg$fail(peg$c39); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c23(s2);
+        s1 = peg$c40(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1224,19 +1595,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c24;
+        s0 = peg$c41;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c42); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c30.test(input.charAt(peg$currPos))) {
+        if (peg$c47.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c48); }
         }
       }
     }
@@ -1249,11 +1620,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c32;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c33); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1264,15 +1635,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c32;
+          s3 = peg$c49;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c34(s2);
+          s1 = peg$c51(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1295,11 +1666,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c35;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c36); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1314,15 +1685,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c35;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c36); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c37(s2);
+          s1 = peg$c54(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1347,19 +1718,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c32;
+      s2 = peg$c49;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c33); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c21;
+        s2 = peg$c38;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
     }
     peg$silentFails--;
@@ -1375,11 +1746,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s2);
+        s1 = peg$c56(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1392,17 +1763,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c21;
+        s1 = peg$c38;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c23(s2);
+          s1 = peg$c40(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1424,19 +1795,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s2 = peg$c35;
+      s2 = peg$c52;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c36); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c21;
+        s2 = peg$c38;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
     }
     peg$silentFails--;
@@ -1452,11 +1823,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s2);
+        s1 = peg$c56(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1469,17 +1840,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c21;
+        s1 = peg$c38;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c23(s2);
+          s1 = peg$c40(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1499,17 +1870,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c40;
+      s1 = peg$c57;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c58); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIntExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s2);
+        s1 = peg$c59(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1528,17 +1899,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 94) {
-      s1 = peg$c43;
+      s1 = peg$c60;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c44); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseNumericExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s2);
+        s1 = peg$c62(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1557,11 +1928,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c40;
+      s1 = peg$c57;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c58); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseDecimalExpr();
@@ -1570,7 +1941,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c46(s2);
+        s1 = peg$c63(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1599,31 +1970,31 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c47) {
-      s1 = peg$c47;
+    if (input.substr(peg$currPos, 2) === peg$c64) {
+      s1 = peg$c64;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c48); }
+      if (peg$silentFails === 0) { peg$fail(peg$c65); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c49.test(input.charAt(peg$currPos))) {
+      if (peg$c66.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c49.test(input.charAt(peg$currPos))) {
+          if (peg$c66.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c67); }
           }
         }
       } else {
@@ -1631,7 +2002,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51(s2);
+        s1 = peg$c68(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1650,22 +2021,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c49.test(input.charAt(peg$currPos))) {
+    if (peg$c66.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c49.test(input.charAt(peg$currPos))) {
+        if (peg$c66.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+          if (peg$silentFails === 0) { peg$fail(peg$c67); }
         }
       }
     } else {
@@ -1673,7 +2044,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c52(s1);
+      s1 = peg$c69(s1);
     }
     s0 = s1;
 
@@ -1684,19 +2055,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 91) {
-      s0 = peg$c53;
+      s0 = peg$c70;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c71); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 123) {
-        s0 = peg$c55;
+        s0 = peg$c72;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c56); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
     }
 
@@ -1707,19 +2078,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 93) {
-      s0 = peg$c57;
+      s0 = peg$c74;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c75); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 125) {
-        s0 = peg$c59;
+        s0 = peg$c76;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
     }
 
@@ -1748,12 +2119,12 @@ function peg$parse(input, options) {
             s5 = peg$parse_();
           }
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c61) {
-              s5 = peg$c61;
+            if (input.substr(peg$currPos, 2) === peg$c78) {
+              s5 = peg$c78;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c62); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
             if (s5 !== peg$FAILED) {
               s6 = [];
@@ -1779,7 +2150,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseRangeCloseOperator();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c63(s1, s3, s7, s9);
+                      s1 = peg$c80(s1, s3, s7, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1837,7 +2208,7 @@ function peg$parse(input, options) {
         s3 = peg$parseRangedTerm();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c64(s2, s3);
+          s1 = peg$c81(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1858,36 +2229,36 @@ function peg$parse(input, options) {
   function peg$parseSingleRangeOperator() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c65) {
-      s0 = peg$c65;
+    if (input.substr(peg$currPos, 2) === peg$c82) {
+      s0 = peg$c82;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c67) {
-        s0 = peg$c67;
+      if (input.substr(peg$currPos, 2) === peg$c84) {
+        s0 = peg$c84;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s0 = peg$c69;
+          s0 = peg$c86;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c87); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 60) {
-            s0 = peg$c71;
+            s0 = peg$c88;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c72); }
+            if (peg$silentFails === 0) { peg$fail(peg$c89); }
           }
         }
       }
@@ -1921,7 +2292,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c73(s2);
+          s1 = peg$c90(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1949,7 +2320,7 @@ function peg$parse(input, options) {
           s3 = peg$parseEOF();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s2);
+            s1 = peg$c90(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1993,7 +2364,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c73(s2);
+          s1 = peg$c90(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2021,7 +2392,7 @@ function peg$parse(input, options) {
           s3 = peg$parseEOF();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s2);
+            s1 = peg$c90(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2065,7 +2436,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c73(s2);
+          s1 = peg$c90(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2093,7 +2464,7 @@ function peg$parse(input, options) {
           s3 = peg$parseEOF();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s2);
+            s1 = peg$c90(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2137,7 +2508,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c73(s2);
+          s1 = peg$c90(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2165,7 +2536,7 @@ function peg$parse(input, options) {
           s3 = peg$parseEOF();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s2);
+            s1 = peg$c90(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2187,36 +2558,36 @@ function peg$parse(input, options) {
   function peg$parsePositiveOperator() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c74) {
-      s0 = peg$c74;
+    if (input.substr(peg$currPos, 2) === peg$c6) {
+      s0 = peg$c6;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c75); }
+      if (peg$silentFails === 0) { peg$fail(peg$c7); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c76) {
-        s0 = peg$c76;
+      if (input.substr(peg$currPos, 3) === peg$c2) {
+        s0 = peg$c2;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c3); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c78) {
-          s0 = peg$c78;
+        if (input.substr(peg$currPos, 2) === peg$c8) {
+          s0 = peg$c8;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c9); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c80) {
-            s0 = peg$c80;
+          if (input.substr(peg$currPos, 2) === peg$c4) {
+            s0 = peg$c4;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c5); }
           }
         }
       }
@@ -2228,20 +2599,20 @@ function peg$parse(input, options) {
   function peg$parseNegativeOperator() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c82) {
-      s0 = peg$c82;
+    if (input.substr(peg$currPos, 3) === peg$c10) {
+      s0 = peg$c10;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+      if (peg$silentFails === 0) { peg$fail(peg$c11); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 33) {
-        s0 = peg$c84;
+        s0 = peg$c12;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
       }
     }
 
@@ -2273,7 +2644,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePrefixOperator();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73(s2);
+        s1 = peg$c90(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2291,27 +2662,27 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c86;
+      s0 = peg$c91;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      if (peg$silentFails === 0) { peg$fail(peg$c92); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c88;
+        s0 = peg$c93;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s0 = peg$c84;
+          s0 = peg$c12;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c13); }
         }
       }
     }
@@ -2324,22 +2695,22 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     s0 = [];
-    if (peg$c91.test(input.charAt(peg$currPos))) {
+    if (peg$c96.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c97); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c91.test(input.charAt(peg$currPos))) {
+        if (peg$c96.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c92); }
+          if (peg$silentFails === 0) { peg$fail(peg$c97); }
         }
       }
     } else {
@@ -2348,7 +2719,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c90); }
+      if (peg$silentFails === 0) { peg$fail(peg$c95); }
     }
 
     return s0;
@@ -2364,7 +2735,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c38); }
+      if (peg$silentFails === 0) { peg$fail(peg$c55); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -2381,171 +2752,171 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c86;
+      s0 = peg$c91;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      if (peg$silentFails === 0) { peg$fail(peg$c92); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c88;
+        s0 = peg$c93;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s0 = peg$c84;
+          s0 = peg$c12;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c13); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s0 = peg$c6;
+            s0 = peg$c18;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c7); }
+            if (peg$silentFails === 0) { peg$fail(peg$c19); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s0 = peg$c8;
+              s0 = peg$c20;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c9); }
+              if (peg$silentFails === 0) { peg$fail(peg$c21); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 123) {
-                s0 = peg$c55;
+                s0 = peg$c72;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                if (peg$silentFails === 0) { peg$fail(peg$c73); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s0 = peg$c59;
+                  s0 = peg$c76;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c60); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c77); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
-                    s0 = peg$c53;
+                    s0 = peg$c70;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c71); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 93) {
-                      s0 = peg$c57;
+                      s0 = peg$c74;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c75); }
                     }
                     if (s0 === peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 94) {
-                        s0 = peg$c43;
+                        s0 = peg$c60;
                         peg$currPos++;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c61); }
                       }
                       if (s0 === peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 34) {
-                          s0 = peg$c32;
+                          s0 = peg$c49;
                           peg$currPos++;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
                         }
                         if (s0 === peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 63) {
-                            s0 = peg$c93;
+                            s0 = peg$c98;
                             peg$currPos++;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c94); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c99); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 58) {
-                              s0 = peg$c95;
+                              s0 = peg$c100;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c101); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 92) {
-                                s0 = peg$c21;
+                                s0 = peg$c38;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c39); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 38) {
-                                  s0 = peg$c97;
+                                  s0 = peg$c102;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c103); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 124) {
-                                    s0 = peg$c99;
+                                    s0 = peg$c104;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c105); }
                                   }
                                   if (s0 === peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 39) {
-                                      s0 = peg$c101;
+                                      s0 = peg$c106;
                                       peg$currPos++;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c107); }
                                     }
                                     if (s0 === peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 47) {
-                                        s0 = peg$c35;
+                                        s0 = peg$c52;
                                         peg$currPos++;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c53); }
                                       }
                                       if (s0 === peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 126) {
-                                          s0 = peg$c40;
+                                          s0 = peg$c57;
                                           peg$currPos++;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c58); }
                                         }
                                         if (s0 === peg$FAILED) {
                                           if (input.charCodeAt(peg$currPos) === 42) {
-                                            s0 = peg$c103;
+                                            s0 = peg$c108;
                                             peg$currPos++;
                                           } else {
                                             s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c104); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c109); }
                                           }
                                           if (s0 === peg$FAILED) {
                                             if (input.charCodeAt(peg$currPos) === 32) {
-                                              s0 = peg$c105;
+                                              s0 = peg$c110;
                                               peg$currPos++;
                                             } else {
                                               s0 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c106); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c111); }
                                             }
                                           }
                                         }
@@ -2575,6 +2946,9 @@ function peg$parse(input, options) {
      var implicit = '<implicit>';
      var wildcard = '*';
      var negativeOps = ['NOT', '!'];
+
+     var leftAssociative = (originalLeft, operator, rest) =>
+       rest.reduce((left, right) => ({ left, operator, right }), originalLeft);
    
 
   peg$result = peg$startRuleFunction();

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -142,7 +142,6 @@ function peg$parse(input, options) {
       peg$startRuleFunction  = peg$parseStart,
 
       peg$c0 = function(node) {
-            //return node;
             if (!node.operator) {
               return {
                 left: node,
@@ -193,22 +192,7 @@ function peg$parse(input, options) {
       peg$c23 = function(left) {
           return left;
         },
-      peg$c24 = function(operator) {
-          return { operator };
-        },
-      peg$c25 = function(operator, left) {
-          return { ...left, type: 'node' };
-        },
-      peg$c26 = function(fieldExp) {
-            return fieldExp;
-          },
-      peg$c27 = function(node) {
-            // I need to better understand this area
-            node[0].parenthesized = true;
-            node[0].type = 'node';
-            return node[0];
-          },
-      peg$c28 = function(prefix, fieldname, range) {
+      peg$c24 = function(prefix, fieldname, range) {
             range.field = fieldname.name;
             range.fieldLocation = fieldname.location;
 
@@ -216,7 +200,7 @@ function peg$parse(input, options) {
 
             return range;
           },
-      peg$c29 = function(prefix, fieldname, range) {
+      peg$c25 = function(prefix, fieldname, range) {
             range.field = fieldname == null || fieldname.name == '' ? implicit : fieldname.name;
             range.fieldLocation = fieldname == null || fieldname.name == '' ? null : fieldname.location;
 
@@ -224,7 +208,7 @@ function peg$parse(input, options) {
 
             return range;
           },
-      peg$c30 = function(prefix, fieldname, node) {
+      peg$c26 = function(prefix, fieldname, node) {
               node.field = fieldname.name;
               node.fieldLocation = fieldname.location;
 
@@ -232,7 +216,7 @@ function peg$parse(input, options) {
 
               return node;
           },
-      peg$c31 = function(prefix, fieldname, term) {
+      peg$c27 = function(prefix, fieldname, term) {
             let fieldexp = {
               field: fieldname == null || fieldname.name == '' ? implicit : fieldname.name,
               fieldLocation: fieldname == null || fieldname.name == '' ? null : fieldname.location,
@@ -246,15 +230,15 @@ function peg$parse(input, options) {
 
             return fieldexp;
           },
-      peg$c32 = /^[:]/,
-      peg$c33 = peg$classExpectation([":"], false, false),
-      peg$c34 = function(fieldname) {
+      peg$c28 = /^[:]/,
+      peg$c29 = peg$classExpectation([":"], false, false),
+      peg$c30 = function(fieldname) {
             return {
               name: fieldname.value,
               location: fieldname.location
             };
           },
-      peg$c35 = function(term, proximity, boost) {
+      peg$c31 = function(term, proximity, boost) {
             let result = {
               term,
               proximity,
@@ -268,7 +252,7 @@ function peg$parse(input, options) {
 
             return result;
           },
-      peg$c36 = function(prefix, term) {
+      peg$c32 = function(prefix, term) {
             let result = {
               term: term,
               quoted: false,
@@ -281,7 +265,7 @@ function peg$parse(input, options) {
 
             return result;
           },
-      peg$c37 = function(prefix, term, similarity, boost) {
+      peg$c33 = function(prefix, term, similarity, boost) {
             return {
               similarity,
               boost,
@@ -293,69 +277,69 @@ function peg$parse(input, options) {
               termLocation: location()
             };
           },
-      peg$c38 = "\\",
-      peg$c39 = peg$literalExpectation("\\", false),
-      peg$c40 = function(sequence) { return '\\' + sequence; },
-      peg$c41 = ".",
-      peg$c42 = peg$literalExpectation(".", false),
-      peg$c43 = /^[^ \t\r\n\f{}()\/\^~[\]]/,
-      peg$c44 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "/", "^", "~", "[", "]"], true, false),
-      peg$c45 = function(term) {
+      peg$c34 = "\\",
+      peg$c35 = peg$literalExpectation("\\", false),
+      peg$c36 = function(sequence) { return '\\' + sequence; },
+      peg$c37 = ".",
+      peg$c38 = peg$literalExpectation(".", false),
+      peg$c39 = /^[^ \t\r\n\f{}()\/\^~[\]]/,
+      peg$c40 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "/", "^", "~", "[", "]"], true, false),
+      peg$c41 = function(term) {
             return {
               value: term.join(''),
               location: location()
             };
           },
-      peg$c46 = function(term) {
+      peg$c42 = function(term) {
             return {
               value: term.join(''),
               location: location(),
             };
           },
-      peg$c47 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
-      peg$c48 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
-      peg$c49 = "\"",
-      peg$c50 = peg$literalExpectation("\"", false),
-      peg$c51 = function(chars) { return chars.join(''); },
-      peg$c52 = "/",
-      peg$c53 = peg$literalExpectation("/", false),
-      peg$c54 = function(chars) { return chars.join('') },
-      peg$c55 = peg$anyExpectation(),
-      peg$c56 = function(char) { return char; },
-      peg$c57 = "~",
-      peg$c58 = peg$literalExpectation("~", false),
-      peg$c59 = function(proximity) {
+      peg$c43 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
+      peg$c44 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
+      peg$c45 = "\"",
+      peg$c46 = peg$literalExpectation("\"", false),
+      peg$c47 = function(chars) { return chars.join(''); },
+      peg$c48 = "/",
+      peg$c49 = peg$literalExpectation("/", false),
+      peg$c50 = function(chars) { return chars.join('') },
+      peg$c51 = peg$anyExpectation(),
+      peg$c52 = function(char) { return char; },
+      peg$c53 = "~",
+      peg$c54 = peg$literalExpectation("~", false),
+      peg$c55 = function(proximity) {
             return proximity;
           },
-      peg$c60 = "^",
-      peg$c61 = peg$literalExpectation("^", false),
-      peg$c62 = function(boost) {
+      peg$c56 = "^",
+      peg$c57 = peg$literalExpectation("^", false),
+      peg$c58 = function(boost) {
             return boost;
           },
-      peg$c63 = function(fuzziness) {
+      peg$c59 = function(fuzziness) {
             return fuzziness == '' || fuzziness == null ? 0.5 : fuzziness;
           },
-      peg$c64 = "0.",
-      peg$c65 = peg$literalExpectation("0.", false),
-      peg$c66 = /^[0-9]/,
-      peg$c67 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c68 = function(val) {
+      peg$c60 = "0.",
+      peg$c61 = peg$literalExpectation("0.", false),
+      peg$c62 = /^[0-9]/,
+      peg$c63 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c64 = function(val) {
             return parseFloat("0." + val.join(''));
           },
-      peg$c69 = function(val) {
+      peg$c65 = function(val) {
             return parseInt(val.join(''));
           },
-      peg$c70 = "[",
-      peg$c71 = peg$literalExpectation("[", false),
-      peg$c72 = "{",
-      peg$c73 = peg$literalExpectation("{", false),
-      peg$c74 = "]",
-      peg$c75 = peg$literalExpectation("]", false),
-      peg$c76 = "}",
-      peg$c77 = peg$literalExpectation("}", false),
-      peg$c78 = "TO",
-      peg$c79 = peg$literalExpectation("TO", false),
-      peg$c80 = function(rangeOpen, termMin, termMax, rangeClose) {
+      peg$c66 = "[",
+      peg$c67 = peg$literalExpectation("[", false),
+      peg$c68 = "{",
+      peg$c69 = peg$literalExpectation("{", false),
+      peg$c70 = "]",
+      peg$c71 = peg$literalExpectation("]", false),
+      peg$c72 = "}",
+      peg$c73 = peg$literalExpectation("}", false),
+      peg$c74 = "TO",
+      peg$c75 = peg$literalExpectation("TO", false),
+      peg$c76 = function(rangeOpen, termMin, termMax, rangeClose) {
             return {
               type: 'range',
               termMin: termMin.value,
@@ -366,7 +350,7 @@ function peg$parse(input, options) {
               maxInclusive: rangeClose === ']'
             };
           },
-      peg$c81 = function(op, term) {
+      peg$c77 = function(op, term) {
             if (op.startsWith('>')) {
               return {
                 type: 'range',
@@ -387,38 +371,35 @@ function peg$parse(input, options) {
               };
             }
           },
-      peg$c82 = ">=",
-      peg$c83 = peg$literalExpectation(">=", false),
-      peg$c84 = "<=",
-      peg$c85 = peg$literalExpectation("<=", false),
-      peg$c86 = ">",
-      peg$c87 = peg$literalExpectation(">", false),
-      peg$c88 = "<",
-      peg$c89 = peg$literalExpectation("<", false),
-      peg$c90 = function(operator) {
-            return operator;
-          },
-      peg$c91 = "+",
-      peg$c92 = peg$literalExpectation("+", false),
-      peg$c93 = "-",
-      peg$c94 = peg$literalExpectation("-", false),
-      peg$c95 = peg$otherExpectation("whitespace"),
-      peg$c96 = /^[ \t\r\n\f]/,
-      peg$c97 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
-      peg$c98 = "?",
-      peg$c99 = peg$literalExpectation("?", false),
-      peg$c100 = ":",
-      peg$c101 = peg$literalExpectation(":", false),
-      peg$c102 = "&",
-      peg$c103 = peg$literalExpectation("&", false),
-      peg$c104 = "|",
-      peg$c105 = peg$literalExpectation("|", false),
-      peg$c106 = "'",
-      peg$c107 = peg$literalExpectation("'", false),
-      peg$c108 = "*",
-      peg$c109 = peg$literalExpectation("*", false),
-      peg$c110 = " ",
-      peg$c111 = peg$literalExpectation(" ", false),
+      peg$c78 = ">=",
+      peg$c79 = peg$literalExpectation(">=", false),
+      peg$c80 = "<=",
+      peg$c81 = peg$literalExpectation("<=", false),
+      peg$c82 = ">",
+      peg$c83 = peg$literalExpectation(">", false),
+      peg$c84 = "<",
+      peg$c85 = peg$literalExpectation("<", false),
+      peg$c86 = "+",
+      peg$c87 = peg$literalExpectation("+", false),
+      peg$c88 = "-",
+      peg$c89 = peg$literalExpectation("-", false),
+      peg$c90 = peg$otherExpectation("whitespace"),
+      peg$c91 = /^[ \t\r\n\f]/,
+      peg$c92 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
+      peg$c93 = "?",
+      peg$c94 = peg$literalExpectation("?", false),
+      peg$c95 = ":",
+      peg$c96 = peg$literalExpectation(":", false),
+      peg$c97 = "&",
+      peg$c98 = peg$literalExpectation("&", false),
+      peg$c99 = "|",
+      peg$c100 = peg$literalExpectation("|", false),
+      peg$c101 = "'",
+      peg$c102 = peg$literalExpectation("'", false),
+      peg$c103 = "*",
+      peg$c104 = peg$literalExpectation("*", false),
+      peg$c105 = " ",
+      peg$c106 = peg$literalExpectation(" ", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1017,182 +998,11 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNode() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    s1 = peg$parseOperatorExpr();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseEOF();
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c24(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseOperatorExpr();
-      if (s1 === peg$FAILED) {
-        s1 = null;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = [];
-        s3 = peg$parse_();
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parse_();
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseClauseOr();
-          if (s3 !== peg$FAILED) {
-            s4 = [];
-            s5 = peg$parse_();
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parse_();
-            }
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseEOF();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c25(s1, s3);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseGroupExpr() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFieldExpr();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parse_();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parse_();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c26(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseParenExpr();
-    }
-
-    return s0;
-  }
-
-  function peg$parseParenExpr() {
-    var s0, s1, s2, s3, s4, s5, s6;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c18;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c19); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parse_();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parse_();
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseNode();
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          s4 = peg$parseNode();
-        }
-        if (s3 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 41) {
-            s4 = peg$c20;
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c21); }
-          }
-          if (s4 !== peg$FAILED) {
-            s5 = [];
-            s6 = peg$parse_();
-            while (s6 !== peg$FAILED) {
-              s5.push(s6);
-              s6 = peg$parse_();
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c27(s3);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseFieldExpr() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parsePrefixOperatorExpr();
+    s1 = peg$parsePrefixOperator();
     if (s1 === peg$FAILED) {
       s1 = null;
     }
@@ -1202,7 +1012,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSingleRangeOperatorExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c28(s1, s2, s3);
+          s1 = peg$c24(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1218,7 +1028,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsePrefixOperatorExpr();
+      s1 = peg$parsePrefixOperator();
       if (s1 === peg$FAILED) {
         s1 = null;
       }
@@ -1231,7 +1041,7 @@ function peg$parse(input, options) {
           s3 = peg$parseRangeOperatorExpr();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c29(s1, s2, s3);
+            s1 = peg$c25(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1247,7 +1057,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parsePrefixOperatorExpr();
+        s1 = peg$parsePrefixOperator();
         if (s1 === peg$FAILED) {
           s1 = null;
         }
@@ -1257,7 +1067,7 @@ function peg$parse(input, options) {
             s3 = peg$parsePrimaryClause();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c30(s1, s2, s3);
+              s1 = peg$c26(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1273,7 +1083,7 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parsePrefixOperatorExpr();
+          s1 = peg$parsePrefixOperator();
           if (s1 === peg$FAILED) {
             s1 = null;
           }
@@ -1286,7 +1096,7 @@ function peg$parse(input, options) {
               s3 = peg$parseTerm();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c31(s1, s2, s3);
+                s1 = peg$c27(s1, s2, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1313,12 +1123,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseUnquotedTerm();
     if (s1 !== peg$FAILED) {
-      if (peg$c32.test(input.charAt(peg$currPos))) {
+      if (peg$c28.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+        if (peg$silentFails === 0) { peg$fail(peg$c29); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -1329,7 +1139,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c34(s1);
+          s1 = peg$c30(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1371,7 +1181,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c35(s1, s2, s3);
+            s1 = peg$c31(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1391,7 +1201,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsePrefixOperatorExpr();
+      s1 = peg$parsePrefixOperator();
       if (s1 === peg$FAILED) {
         s1 = null;
       }
@@ -1406,7 +1216,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c36(s1, s2);
+            s1 = peg$c32(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1422,7 +1232,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parsePrefixOperatorExpr();
+        s1 = peg$parsePrefixOperator();
         if (s1 === peg$FAILED) {
           s1 = null;
         }
@@ -1447,7 +1257,7 @@ function peg$parse(input, options) {
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c37(s1, s2, s3, s4);
+                  s1 = peg$c33(s1, s2, s3, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1480,17 +1290,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c38;
+      s1 = peg$c34;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c40(s2);
+        s1 = peg$c36(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1502,19 +1312,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c41;
+        s0 = peg$c37;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c39.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c40); }
         }
       }
     }
@@ -1538,7 +1348,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c45(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
 
@@ -1561,7 +1371,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c46(s1);
+      s1 = peg$c42(s1);
     }
     s0 = s1;
 
@@ -1573,17 +1383,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c38;
+      s1 = peg$c34;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c40(s2);
+        s1 = peg$c36(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1595,19 +1405,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c41;
+        s0 = peg$c37;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c47.test(input.charAt(peg$currPos))) {
+        if (peg$c43.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c48); }
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
         }
       }
     }
@@ -1620,11 +1430,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c49;
+      s1 = peg$c45;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c46); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1635,15 +1445,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c49;
+          s3 = peg$c45;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c51(s2);
+          s1 = peg$c47(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1666,11 +1476,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c52;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1685,15 +1495,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c52;
+          s3 = peg$c48;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c54(s2);
+          s1 = peg$c50(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1718,19 +1528,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c49;
+      s2 = peg$c45;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c46); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c38;
+        s2 = peg$c34;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
     }
     peg$silentFails--;
@@ -1746,11 +1556,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c56(s2);
+        s1 = peg$c52(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1763,17 +1573,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c38;
+        s1 = peg$c34;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c40(s2);
+          s1 = peg$c36(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1795,19 +1605,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s2 = peg$c52;
+      s2 = peg$c48;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c38;
+        s2 = peg$c34;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
     }
     peg$silentFails--;
@@ -1823,11 +1633,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c56(s2);
+        s1 = peg$c52(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1840,17 +1650,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c38;
+        s1 = peg$c34;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c40(s2);
+          s1 = peg$c36(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1870,17 +1680,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c57;
+      s1 = peg$c53;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c54); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIntExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c59(s2);
+        s1 = peg$c55(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1899,17 +1709,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 94) {
-      s1 = peg$c60;
+      s1 = peg$c56;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseNumericExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s2);
+        s1 = peg$c58(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1928,11 +1738,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c57;
+      s1 = peg$c53;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c54); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseDecimalExpr();
@@ -1941,7 +1751,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c63(s2);
+        s1 = peg$c59(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1970,31 +1780,31 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c64) {
-      s1 = peg$c64;
+    if (input.substr(peg$currPos, 2) === peg$c60) {
+      s1 = peg$c60;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c66.test(input.charAt(peg$currPos))) {
+      if (peg$c62.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c63); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c66.test(input.charAt(peg$currPos))) {
+          if (peg$c62.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c67); }
+            if (peg$silentFails === 0) { peg$fail(peg$c63); }
           }
         }
       } else {
@@ -2002,7 +1812,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c68(s2);
+        s1 = peg$c64(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2021,22 +1831,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c66.test(input.charAt(peg$currPos))) {
+    if (peg$c62.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c67); }
+      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c66.test(input.charAt(peg$currPos))) {
+        if (peg$c62.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c63); }
         }
       }
     } else {
@@ -2044,7 +1854,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c69(s1);
+      s1 = peg$c65(s1);
     }
     s0 = s1;
 
@@ -2055,19 +1865,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 91) {
-      s0 = peg$c70;
+      s0 = peg$c66;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c71); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 123) {
-        s0 = peg$c72;
+        s0 = peg$c68;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c73); }
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
       }
     }
 
@@ -2078,19 +1888,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 93) {
-      s0 = peg$c74;
+      s0 = peg$c70;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c75); }
+      if (peg$silentFails === 0) { peg$fail(peg$c71); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 125) {
-        s0 = peg$c76;
+        s0 = peg$c72;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
     }
 
@@ -2119,12 +1929,12 @@ function peg$parse(input, options) {
             s5 = peg$parse_();
           }
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c78) {
-              s5 = peg$c78;
+            if (input.substr(peg$currPos, 2) === peg$c74) {
+              s5 = peg$c74;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c79); }
+              if (peg$silentFails === 0) { peg$fail(peg$c75); }
             }
             if (s5 !== peg$FAILED) {
               s6 = [];
@@ -2150,7 +1960,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseRangeCloseOperator();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c80(s1, s3, s7, s9);
+                      s1 = peg$c76(s1, s3, s7, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2208,7 +2018,7 @@ function peg$parse(input, options) {
         s3 = peg$parseRangedTerm();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c81(s2, s3);
+          s1 = peg$c77(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2229,430 +2039,39 @@ function peg$parse(input, options) {
   function peg$parseSingleRangeOperator() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c82) {
-      s0 = peg$c82;
+    if (input.substr(peg$currPos, 2) === peg$c78) {
+      s0 = peg$c78;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c84) {
-        s0 = peg$c84;
+      if (input.substr(peg$currPos, 2) === peg$c80) {
+        s0 = peg$c80;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s0 = peg$c86;
+          s0 = peg$c82;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c87); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 60) {
-            s0 = peg$c88;
+            s0 = peg$c84;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
         }
       }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSingleExpr() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parse_();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parse_();
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseOperator();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parse_();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c90(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parse_();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parse_();
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseOperator();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseEOF();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c90(s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseOperatorExpr() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parse_();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parse_();
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseOperator();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parse_();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c90(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parse_();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parse_();
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseOperator();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseEOF();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c90(s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parsePositiveOperatorExpr() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parse_();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parse_();
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsePositiveOperator();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parse_();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c90(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parse_();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parse_();
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsePositiveOperator();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseEOF();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c90(s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseNegativeOperatorExpr() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parse_();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parse_();
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseNegativeOperator();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parse_();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c90(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parse_();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parse_();
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseNegativeOperator();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseEOF();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c90(s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parsePositiveOperator() {
-    var s0;
-
-    if (input.substr(peg$currPos, 2) === peg$c6) {
-      s0 = peg$c6;
-      peg$currPos += 2;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c7); }
-    }
-    if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c2) {
-        s0 = peg$c2;
-        peg$currPos += 3;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c3); }
-      }
-      if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c8) {
-          s0 = peg$c8;
-          peg$currPos += 2;
-        } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c9); }
-        }
-        if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c4) {
-            s0 = peg$c4;
-            peg$currPos += 2;
-          } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c5); }
-          }
-        }
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseNegativeOperator() {
-    var s0;
-
-    if (input.substr(peg$currPos, 3) === peg$c10) {
-      s0 = peg$c10;
-      peg$currPos += 3;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c11); }
-    }
-    if (s0 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 33) {
-        s0 = peg$c12;
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseOperator() {
-    var s0;
-
-    s0 = peg$parsePositiveOperator();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseNegativeOperator();
-    }
-
-    return s0;
-  }
-
-  function peg$parsePrefixOperatorExpr() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parse_();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parse_();
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsePrefixOperator();
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c90(s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
     }
 
     return s0;
@@ -2662,19 +2081,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c91;
+      s0 = peg$c86;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c93;
+        s0 = peg$c88;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
@@ -2695,22 +2114,22 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     s0 = [];
-    if (peg$c96.test(input.charAt(peg$currPos))) {
+    if (peg$c91.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c97); }
+      if (peg$silentFails === 0) { peg$fail(peg$c92); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c96.test(input.charAt(peg$currPos))) {
+        if (peg$c91.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c97); }
+          if (peg$silentFails === 0) { peg$fail(peg$c92); }
         }
       }
     } else {
@@ -2719,7 +2138,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c95); }
+      if (peg$silentFails === 0) { peg$fail(peg$c90); }
     }
 
     return s0;
@@ -2735,7 +2154,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -2752,19 +2171,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c91;
+      s0 = peg$c86;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c93;
+        s0 = peg$c88;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
@@ -2792,131 +2211,131 @@ function peg$parse(input, options) {
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 123) {
-                s0 = peg$c72;
+                s0 = peg$c68;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c73); }
+                if (peg$silentFails === 0) { peg$fail(peg$c69); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s0 = peg$c76;
+                  s0 = peg$c72;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c77); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c73); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
-                    s0 = peg$c70;
+                    s0 = peg$c66;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c71); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c67); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 93) {
-                      s0 = peg$c74;
+                      s0 = peg$c70;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c75); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c71); }
                     }
                     if (s0 === peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 94) {
-                        s0 = peg$c60;
+                        s0 = peg$c56;
                         peg$currPos++;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c57); }
                       }
                       if (s0 === peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 34) {
-                          s0 = peg$c49;
+                          s0 = peg$c45;
                           peg$currPos++;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c46); }
                         }
                         if (s0 === peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 63) {
-                            s0 = peg$c98;
+                            s0 = peg$c93;
                             peg$currPos++;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c94); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 58) {
-                              s0 = peg$c100;
+                              s0 = peg$c95;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c96); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 92) {
-                                s0 = peg$c38;
+                                s0 = peg$c34;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c39); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c35); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 38) {
-                                  s0 = peg$c102;
+                                  s0 = peg$c97;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c98); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 124) {
-                                    s0 = peg$c104;
+                                    s0 = peg$c99;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c100); }
                                   }
                                   if (s0 === peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 39) {
-                                      s0 = peg$c106;
+                                      s0 = peg$c101;
                                       peg$currPos++;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c107); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c102); }
                                     }
                                     if (s0 === peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 47) {
-                                        s0 = peg$c52;
+                                        s0 = peg$c48;
                                         peg$currPos++;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c49); }
                                       }
                                       if (s0 === peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 126) {
-                                          s0 = peg$c57;
+                                          s0 = peg$c53;
                                           peg$currPos++;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c58); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c54); }
                                         }
                                         if (s0 === peg$FAILED) {
                                           if (input.charCodeAt(peg$currPos) === 42) {
-                                            s0 = peg$c108;
+                                            s0 = peg$c103;
                                             peg$currPos++;
                                           } else {
                                             s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c109); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c104); }
                                           }
                                           if (s0 === peg$FAILED) {
                                             if (input.charCodeAt(peg$currPos) === 32) {
-                                              s0 = peg$c110;
+                                              s0 = peg$c105;
                                               peg$currPos++;
                                             } else {
                                               s0 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c106); }
                                             }
                                           }
                                         }
@@ -2945,7 +2364,6 @@ function peg$parse(input, options) {
 
      var implicit = '<implicit>';
      var wildcard = '*';
-     var negativeOps = ['NOT', '!'];
 
      var leftAssociative = (originalLeft, operator, rest) =>
        rest.reduce((left, right) => ({ left, operator, right }), originalLeft);

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -141,58 +141,48 @@ function peg$parse(input, options) {
       peg$startRuleFunctions = { Start: peg$parseStart },
       peg$startRuleFunction  = peg$parseStart,
 
-      peg$c0 = function(node) {
-            if (!node.operator) {
-              return {
-                left: node,
-                type: 'node',
-              }
-            }
-
-            return { ...node, type: 'node' };
-          },
-      peg$c1 = function() {
-            return {};
-          },
-      peg$c2 = "AND",
-      peg$c3 = peg$literalExpectation("AND", false),
-      peg$c4 = "&&",
-      peg$c5 = peg$literalExpectation("&&", false),
-      peg$c6 = "OR",
-      peg$c7 = peg$literalExpectation("OR", false),
-      peg$c8 = "||",
-      peg$c9 = peg$literalExpectation("||", false),
-      peg$c10 = "NOT",
-      peg$c11 = peg$literalExpectation("NOT", false),
-      peg$c12 = "!",
-      peg$c13 = peg$literalExpectation("!", false),
-      peg$c14 = function(left, operator, rest) {
+      peg$c0 = function(operator) { return { operator }; },
+      peg$c1 = function(node) { return wrapInNode(node); },
+      peg$c2 = function() { return {}; },
+      peg$c3 = "AND",
+      peg$c4 = peg$literalExpectation("AND", false),
+      peg$c5 = "&&",
+      peg$c6 = peg$literalExpectation("&&", false),
+      peg$c7 = "OR",
+      peg$c8 = peg$literalExpectation("OR", false),
+      peg$c9 = "||",
+      peg$c10 = peg$literalExpectation("||", false),
+      peg$c11 = "NOT",
+      peg$c12 = peg$literalExpectation("NOT", false),
+      peg$c13 = "!",
+      peg$c14 = peg$literalExpectation("!", false),
+      peg$c15 = function(left, operator, rest) {
           return leftAssociative(left, operator || implicit, rest);
         },
-      peg$c15 = function(left, rest) {
+      peg$c16 = function(left, rest) {
           return leftAssociative(left, implicit, rest);
         },
-      peg$c16 = function(left, operator, right) {
+      peg$c17 = function(left, operator, right) {
           return { left, operator, right, type: 'node'}
         },
-      peg$c17 = function(operator, left) {
+      peg$c18 = function(operator, left) {
           return { left, operator, right: null, type: 'node'};
         },
-      peg$c18 = "(",
-      peg$c19 = peg$literalExpectation("(", false),
-      peg$c20 = ")",
-      peg$c21 = peg$literalExpectation(")", false),
-      peg$c22 = function(left) {
+      peg$c19 = "(",
+      peg$c20 = peg$literalExpectation("(", false),
+      peg$c21 = ")",
+      peg$c22 = peg$literalExpectation(")", false),
+      peg$c23 = function(left) {
           if (left && left.left) {
             return {...left, type: 'node', parenthesized: true };
           }
 
           return { left, type: 'node', parenthesized: true };
           },
-      peg$c23 = function(left) {
+      peg$c24 = function(left) {
           return left;
         },
-      peg$c24 = function(prefix, fieldname, range) {
+      peg$c25 = function(prefix, fieldname, range) {
             range.field = fieldname.name;
             range.fieldLocation = fieldname.location;
 
@@ -200,7 +190,7 @@ function peg$parse(input, options) {
 
             return range;
           },
-      peg$c25 = function(prefix, fieldname, range) {
+      peg$c26 = function(prefix, fieldname, range) {
             range.field = fieldname == null || fieldname.name == '' ? implicit : fieldname.name;
             range.fieldLocation = fieldname == null || fieldname.name == '' ? null : fieldname.location;
 
@@ -208,7 +198,7 @@ function peg$parse(input, options) {
 
             return range;
           },
-      peg$c26 = function(prefix, fieldname, node) {
+      peg$c27 = function(prefix, fieldname, node) {
               node.field = fieldname.name;
               node.fieldLocation = fieldname.location;
 
@@ -216,7 +206,7 @@ function peg$parse(input, options) {
 
               return node;
           },
-      peg$c27 = function(prefix, fieldname, term) {
+      peg$c28 = function(prefix, fieldname, term) {
             let fieldexp = {
               field: fieldname == null || fieldname.name == '' ? implicit : fieldname.name,
               fieldLocation: fieldname == null || fieldname.name == '' ? null : fieldname.location,
@@ -230,15 +220,15 @@ function peg$parse(input, options) {
 
             return fieldexp;
           },
-      peg$c28 = /^[:]/,
-      peg$c29 = peg$classExpectation([":"], false, false),
-      peg$c30 = function(fieldname) {
+      peg$c29 = /^[:]/,
+      peg$c30 = peg$classExpectation([":"], false, false),
+      peg$c31 = function(fieldname) {
             return {
               name: fieldname.value,
               location: fieldname.location
             };
           },
-      peg$c31 = function(term, proximity, boost) {
+      peg$c32 = function(term, proximity, boost) {
             let result = {
               term,
               proximity,
@@ -252,7 +242,7 @@ function peg$parse(input, options) {
 
             return result;
           },
-      peg$c32 = function(prefix, term) {
+      peg$c33 = function(prefix, term) {
             let result = {
               term: term,
               quoted: false,
@@ -265,7 +255,7 @@ function peg$parse(input, options) {
 
             return result;
           },
-      peg$c33 = function(prefix, term, similarity, boost) {
+      peg$c34 = function(prefix, term, similarity, boost) {
             return {
               similarity,
               boost,
@@ -277,69 +267,74 @@ function peg$parse(input, options) {
               termLocation: location()
             };
           },
-      peg$c34 = "\\",
-      peg$c35 = peg$literalExpectation("\\", false),
-      peg$c36 = function(sequence) { return '\\' + sequence; },
-      peg$c37 = ".",
-      peg$c38 = peg$literalExpectation(".", false),
-      peg$c39 = /^[^ \t\r\n\f{}()\/\^~[\]]/,
-      peg$c40 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "/", "^", "~", "[", "]"], true, false),
-      peg$c41 = function(term) {
+      peg$c35 = "\\",
+      peg$c36 = peg$literalExpectation("\\", false),
+      peg$c37 = function(sequence) { return '\\' + sequence; },
+      peg$c38 = ".",
+      peg$c39 = peg$literalExpectation(".", false),
+      peg$c40 = /^[^ \t\r\n\f{}()\/\^~[\]]/,
+      peg$c41 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "/", "^", "~", "[", "]"], true, false),
+      peg$c42 = function(term) {
             return {
               value: term.join(''),
               location: location()
             };
           },
-      peg$c42 = function(term) {
+      peg$c43 = function(term) {
             return {
               value: term.join(''),
               location: location(),
             };
           },
-      peg$c43 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
-      peg$c44 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
-      peg$c45 = "\"",
-      peg$c46 = peg$literalExpectation("\"", false),
-      peg$c47 = function(chars) { return chars.join(''); },
-      peg$c48 = "/",
-      peg$c49 = peg$literalExpectation("/", false),
-      peg$c50 = function(chars) { return chars.join('') },
-      peg$c51 = peg$anyExpectation(),
-      peg$c52 = function(char) { return char; },
-      peg$c53 = "~",
-      peg$c54 = peg$literalExpectation("~", false),
-      peg$c55 = function(proximity) {
+      peg$c44 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
+      peg$c45 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
+      peg$c46 = "\"",
+      peg$c47 = peg$literalExpectation("\"", false),
+      peg$c48 = function(chars) { return chars.join(''); },
+      peg$c49 = "/",
+      peg$c50 = peg$literalExpectation("/", false),
+      peg$c51 = function(chars) { return chars.join('') },
+      peg$c52 = peg$anyExpectation(),
+      peg$c53 = function(char) { return char; },
+      peg$c54 = /^[^"\\]/,
+      peg$c55 = peg$classExpectation(["\"", "\\"], true, false),
+      peg$c56 = function(char) { return '\\' + char; },
+      peg$c57 = /^[^"\\?*]/,
+      peg$c58 = peg$classExpectation(["\"", "\\", "?", "*"], true, false),
+      peg$c59 = "~",
+      peg$c60 = peg$literalExpectation("~", false),
+      peg$c61 = function(proximity) {
             return proximity;
           },
-      peg$c56 = "^",
-      peg$c57 = peg$literalExpectation("^", false),
-      peg$c58 = function(boost) {
+      peg$c62 = "^",
+      peg$c63 = peg$literalExpectation("^", false),
+      peg$c64 = function(boost) {
             return boost;
           },
-      peg$c59 = function(fuzziness) {
+      peg$c65 = function(fuzziness) {
             return fuzziness == '' || fuzziness == null ? 0.5 : fuzziness;
           },
-      peg$c60 = "0.",
-      peg$c61 = peg$literalExpectation("0.", false),
-      peg$c62 = /^[0-9]/,
-      peg$c63 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c64 = function(val) {
+      peg$c66 = "0.",
+      peg$c67 = peg$literalExpectation("0.", false),
+      peg$c68 = /^[0-9]/,
+      peg$c69 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c70 = function(val) {
             return parseFloat("0." + val.join(''));
           },
-      peg$c65 = function(val) {
+      peg$c71 = function(val) {
             return parseInt(val.join(''));
           },
-      peg$c66 = "[",
-      peg$c67 = peg$literalExpectation("[", false),
-      peg$c68 = "{",
-      peg$c69 = peg$literalExpectation("{", false),
-      peg$c70 = "]",
-      peg$c71 = peg$literalExpectation("]", false),
-      peg$c72 = "}",
-      peg$c73 = peg$literalExpectation("}", false),
-      peg$c74 = "TO",
-      peg$c75 = peg$literalExpectation("TO", false),
-      peg$c76 = function(rangeOpen, termMin, termMax, rangeClose) {
+      peg$c72 = "[",
+      peg$c73 = peg$literalExpectation("[", false),
+      peg$c74 = "{",
+      peg$c75 = peg$literalExpectation("{", false),
+      peg$c76 = "]",
+      peg$c77 = peg$literalExpectation("]", false),
+      peg$c78 = "}",
+      peg$c79 = peg$literalExpectation("}", false),
+      peg$c80 = "TO",
+      peg$c81 = peg$literalExpectation("TO", false),
+      peg$c82 = function(rangeOpen, termMin, termMax, rangeClose) {
             return {
               type: 'range',
               termMin: termMin.value,
@@ -350,7 +345,7 @@ function peg$parse(input, options) {
               maxInclusive: rangeClose === ']'
             };
           },
-      peg$c77 = function(op, term) {
+      peg$c83 = function(op, term) {
             if (op.startsWith('>')) {
               return {
                 type: 'range',
@@ -371,35 +366,35 @@ function peg$parse(input, options) {
               };
             }
           },
-      peg$c78 = ">=",
-      peg$c79 = peg$literalExpectation(">=", false),
-      peg$c80 = "<=",
-      peg$c81 = peg$literalExpectation("<=", false),
-      peg$c82 = ">",
-      peg$c83 = peg$literalExpectation(">", false),
-      peg$c84 = "<",
-      peg$c85 = peg$literalExpectation("<", false),
-      peg$c86 = "+",
-      peg$c87 = peg$literalExpectation("+", false),
-      peg$c88 = "-",
-      peg$c89 = peg$literalExpectation("-", false),
-      peg$c90 = peg$otherExpectation("whitespace"),
-      peg$c91 = /^[ \t\r\n\f]/,
-      peg$c92 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
-      peg$c93 = "?",
-      peg$c94 = peg$literalExpectation("?", false),
-      peg$c95 = ":",
-      peg$c96 = peg$literalExpectation(":", false),
-      peg$c97 = "&",
-      peg$c98 = peg$literalExpectation("&", false),
-      peg$c99 = "|",
-      peg$c100 = peg$literalExpectation("|", false),
-      peg$c101 = "'",
-      peg$c102 = peg$literalExpectation("'", false),
-      peg$c103 = "*",
-      peg$c104 = peg$literalExpectation("*", false),
-      peg$c105 = " ",
-      peg$c106 = peg$literalExpectation(" ", false),
+      peg$c84 = ">=",
+      peg$c85 = peg$literalExpectation(">=", false),
+      peg$c86 = "<=",
+      peg$c87 = peg$literalExpectation("<=", false),
+      peg$c88 = ">",
+      peg$c89 = peg$literalExpectation(">", false),
+      peg$c90 = "<",
+      peg$c91 = peg$literalExpectation("<", false),
+      peg$c92 = "+",
+      peg$c93 = peg$literalExpectation("+", false),
+      peg$c94 = "-",
+      peg$c95 = peg$literalExpectation("-", false),
+      peg$c96 = peg$otherExpectation("whitespace"),
+      peg$c97 = /^[ \t\r\n\f]/,
+      peg$c98 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
+      peg$c99 = "?",
+      peg$c100 = peg$literalExpectation("?", false),
+      peg$c101 = ":",
+      peg$c102 = peg$literalExpectation(":", false),
+      peg$c103 = "&",
+      peg$c104 = peg$literalExpectation("&", false),
+      peg$c105 = "|",
+      peg$c106 = peg$literalExpectation("|", false),
+      peg$c107 = "'",
+      peg$c108 = peg$literalExpectation("'", false),
+      peg$c109 = "*",
+      peg$c110 = peg$literalExpectation("*", false),
+      peg$c111 = " ",
+      peg$c112 = peg$literalExpectation(" ", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -538,21 +533,27 @@ function peg$parse(input, options) {
   }
 
   function peg$parseStart() {
-    var s0, s1, s2;
+    var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parse_();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parse_();
-    }
+    s1 = peg$parseBooleanOperator();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseClauseOr();
+      s2 = [];
+      s3 = peg$parse_();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parse_();
+      }
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c0(s2);
-        s0 = s1;
+        s3 = peg$parseEOF();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c0(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -563,26 +564,100 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parse_();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parse_();
-      }
+      s1 = peg$parseBinaryOperator();
       if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c1();
+        s2 = [];
+        s3 = peg$parse_();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parse_();
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseClauseOr();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c1(s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
-      s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseEOF();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c1();
+        s1 = [];
+        s2 = peg$parse_();
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = peg$parse_();
         }
-        s0 = s1;
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseClauseOr();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c1(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = [];
+          s2 = peg$parse_();
+          while (s2 !== peg$FAILED) {
+            s1.push(s2);
+            s2 = peg$parse_();
+          }
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c2();
+          }
+          s0 = s1;
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseEOF();
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c2();
+            }
+            s0 = s1;
+          }
+        }
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseBooleanOperator() {
+    var s0;
+
+    s0 = peg$parseBinaryOperator();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseLogicalNot();
+    }
+
+    return s0;
+  }
+
+  function peg$parseBinaryOperator() {
+    var s0;
+
+    s0 = peg$parseLogicalAnd();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseLogicalOr();
     }
 
     return s0;
@@ -591,20 +666,20 @@ function peg$parse(input, options) {
   function peg$parseLogicalAnd() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c2) {
-      s0 = peg$c2;
+    if (input.substr(peg$currPos, 3) === peg$c3) {
+      s0 = peg$c3;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c3); }
+      if (peg$silentFails === 0) { peg$fail(peg$c4); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c4) {
-        s0 = peg$c4;
+      if (input.substr(peg$currPos, 2) === peg$c5) {
+        s0 = peg$c5;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c5); }
+        if (peg$silentFails === 0) { peg$fail(peg$c6); }
       }
     }
 
@@ -614,20 +689,20 @@ function peg$parse(input, options) {
   function peg$parseLogicalOr() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c6) {
-      s0 = peg$c6;
+    if (input.substr(peg$currPos, 2) === peg$c7) {
+      s0 = peg$c7;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c7); }
+      if (peg$silentFails === 0) { peg$fail(peg$c8); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c8) {
-        s0 = peg$c8;
+      if (input.substr(peg$currPos, 2) === peg$c9) {
+        s0 = peg$c9;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+        if (peg$silentFails === 0) { peg$fail(peg$c10); }
       }
     }
 
@@ -637,20 +712,20 @@ function peg$parse(input, options) {
   function peg$parseLogicalNot() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c10) {
-      s0 = peg$c10;
+    if (input.substr(peg$currPos, 3) === peg$c11) {
+      s0 = peg$c11;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c11); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 33) {
-        s0 = peg$c12;
+        s0 = peg$c13;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
       }
     }
 
@@ -694,7 +769,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c14(s2, s4, s6);
+                s1 = peg$c15(s2, s4, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -746,7 +821,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c15(s2, s4);
+              s1 = peg$c16(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -815,7 +890,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c16(s2, s4, s6);
+                  s1 = peg$c17(s2, s4, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -886,7 +961,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c17(s2, s4);
+              s1 = peg$c18(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -927,11 +1002,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 40) {
-        s2 = peg$c18;
+        s2 = peg$c19;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c20); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -951,15 +1026,15 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s6 = peg$c20;
+                s6 = peg$c21;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                if (peg$silentFails === 0) { peg$fail(peg$c22); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c22(s4);
+                s1 = peg$c23(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -990,7 +1065,7 @@ function peg$parse(input, options) {
       s1 = peg$parseFieldExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c23(s1);
+        s1 = peg$c24(s1);
       }
       s0 = s1;
     }
@@ -1012,7 +1087,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSingleRangeOperatorExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c24(s1, s2, s3);
+          s1 = peg$c25(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1041,7 +1116,7 @@ function peg$parse(input, options) {
           s3 = peg$parseRangeOperatorExpr();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c25(s1, s2, s3);
+            s1 = peg$c26(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1067,7 +1142,7 @@ function peg$parse(input, options) {
             s3 = peg$parsePrimaryClause();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c26(s1, s2, s3);
+              s1 = peg$c27(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1096,7 +1171,7 @@ function peg$parse(input, options) {
               s3 = peg$parseTerm();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c27(s1, s2, s3);
+                s1 = peg$c28(s1, s2, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1123,12 +1198,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseUnquotedTerm();
     if (s1 !== peg$FAILED) {
-      if (peg$c28.test(input.charAt(peg$currPos))) {
+      if (peg$c29.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -1139,7 +1214,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c30(s1);
+          s1 = peg$c31(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1181,7 +1256,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c31(s1, s2, s3);
+            s1 = peg$c32(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1216,7 +1291,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c32(s1, s2);
+            s1 = peg$c33(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1257,7 +1332,7 @@ function peg$parse(input, options) {
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c33(s1, s2, s3, s4);
+                  s1 = peg$c34(s1, s2, s3, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1290,17 +1365,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c34;
+      s1 = peg$c35;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c36(s2);
+        s1 = peg$c37(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1312,19 +1387,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c37;
+        s0 = peg$c38;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c39.test(input.charAt(peg$currPos))) {
+        if (peg$c40.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
       }
     }
@@ -1348,7 +1423,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c41(s1);
+      s1 = peg$c42(s1);
     }
     s0 = s1;
 
@@ -1371,7 +1446,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c42(s1);
+      s1 = peg$c43(s1);
     }
     s0 = s1;
 
@@ -1383,17 +1458,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c34;
+      s1 = peg$c35;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c36(s2);
+        s1 = peg$c37(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1405,19 +1480,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c37;
+        s0 = peg$c38;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c44.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c45); }
         }
       }
     }
@@ -1430,11 +1505,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c45;
+      s1 = peg$c46;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c46); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1445,15 +1520,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c45;
+          s3 = peg$c46;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c46); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c47(s2);
+          s1 = peg$c48(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1476,11 +1551,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c48;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1495,15 +1570,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c48;
+          s3 = peg$c49;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c50(s2);
+          s1 = peg$c51(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1528,19 +1603,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c45;
+      s2 = peg$c46;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c46); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c34;
+        s2 = peg$c35;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
     }
     peg$silentFails--;
@@ -1556,11 +1631,73 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s2);
+        s1 = peg$c53(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseEscapedChar();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 92) {
+          s1 = peg$c35;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseEscapeSequence();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c37(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseEscapedChar() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 92) {
+      s1 = peg$c35;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
+    }
+    if (s1 !== peg$FAILED) {
+      if (peg$c54.test(input.charAt(peg$currPos))) {
+        s2 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c56(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1573,17 +1710,23 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c34;
+        s1 = peg$c35;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseEscapeSequence();
+        if (peg$c57.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c58); }
+        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c36(s2);
+          s1 = peg$c56(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1605,19 +1748,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s2 = peg$c48;
+      s2 = peg$c49;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c34;
+        s2 = peg$c35;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
     }
     peg$silentFails--;
@@ -1633,11 +1776,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s2);
+        s1 = peg$c53(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1650,17 +1793,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c34;
+        s1 = peg$c35;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c36(s2);
+          s1 = peg$c37(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1680,17 +1823,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c53;
+      s1 = peg$c59;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c60); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIntExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55(s2);
+        s1 = peg$c61(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1709,17 +1852,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 94) {
-      s1 = peg$c56;
+      s1 = peg$c62;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
+      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseNumericExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c58(s2);
+        s1 = peg$c64(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1738,11 +1881,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c53;
+      s1 = peg$c59;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c60); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseDecimalExpr();
@@ -1751,7 +1894,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c59(s2);
+        s1 = peg$c65(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1780,31 +1923,31 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c60) {
-      s1 = peg$c60;
+    if (input.substr(peg$currPos, 2) === peg$c66) {
+      s1 = peg$c66;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c62.test(input.charAt(peg$currPos))) {
+      if (peg$c68.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c62.test(input.charAt(peg$currPos))) {
+          if (peg$c68.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c63); }
+            if (peg$silentFails === 0) { peg$fail(peg$c69); }
           }
         }
       } else {
@@ -1812,7 +1955,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64(s2);
+        s1 = peg$c70(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1831,22 +1974,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c62.test(input.charAt(peg$currPos))) {
+    if (peg$c68.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c63); }
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c62.test(input.charAt(peg$currPos))) {
+        if (peg$c68.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c63); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
       }
     } else {
@@ -1854,7 +1997,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c65(s1);
+      s1 = peg$c71(s1);
     }
     s0 = s1;
 
@@ -1865,19 +2008,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 91) {
-      s0 = peg$c66;
+      s0 = peg$c72;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c67); }
+      if (peg$silentFails === 0) { peg$fail(peg$c73); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 123) {
-        s0 = peg$c68;
+        s0 = peg$c74;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c75); }
       }
     }
 
@@ -1888,19 +2031,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 93) {
-      s0 = peg$c70;
+      s0 = peg$c76;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c71); }
+      if (peg$silentFails === 0) { peg$fail(peg$c77); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 125) {
-        s0 = peg$c72;
+        s0 = peg$c78;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c73); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
     }
 
@@ -1929,12 +2072,12 @@ function peg$parse(input, options) {
             s5 = peg$parse_();
           }
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c74) {
-              s5 = peg$c74;
+            if (input.substr(peg$currPos, 2) === peg$c80) {
+              s5 = peg$c80;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c75); }
+              if (peg$silentFails === 0) { peg$fail(peg$c81); }
             }
             if (s5 !== peg$FAILED) {
               s6 = [];
@@ -1960,7 +2103,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseRangeCloseOperator();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c76(s1, s3, s7, s9);
+                      s1 = peg$c82(s1, s3, s7, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2018,7 +2161,7 @@ function peg$parse(input, options) {
         s3 = peg$parseRangedTerm();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c77(s2, s3);
+          s1 = peg$c83(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2039,36 +2182,36 @@ function peg$parse(input, options) {
   function peg$parseSingleRangeOperator() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c78) {
-      s0 = peg$c78;
+    if (input.substr(peg$currPos, 2) === peg$c84) {
+      s0 = peg$c84;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c79); }
+      if (peg$silentFails === 0) { peg$fail(peg$c85); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c80) {
-        s0 = peg$c80;
+      if (input.substr(peg$currPos, 2) === peg$c86) {
+        s0 = peg$c86;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s0 = peg$c82;
+          s0 = peg$c88;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c83); }
+          if (peg$silentFails === 0) { peg$fail(peg$c89); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 60) {
-            s0 = peg$c84;
+            s0 = peg$c90;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c91); }
           }
         }
       }
@@ -2081,27 +2224,27 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c86;
+      s0 = peg$c92;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      if (peg$silentFails === 0) { peg$fail(peg$c93); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c88;
+        s0 = peg$c94;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c95); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s0 = peg$c12;
+          s0 = peg$c13;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c13); }
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
         }
       }
     }
@@ -2114,22 +2257,22 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     s0 = [];
-    if (peg$c91.test(input.charAt(peg$currPos))) {
+    if (peg$c97.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c98); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c91.test(input.charAt(peg$currPos))) {
+        if (peg$c97.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c92); }
+          if (peg$silentFails === 0) { peg$fail(peg$c98); }
         }
       }
     } else {
@@ -2138,7 +2281,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c90); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
 
     return s0;
@@ -2154,7 +2297,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c52); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -2171,171 +2314,171 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c86;
+      s0 = peg$c92;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      if (peg$silentFails === 0) { peg$fail(peg$c93); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c88;
+        s0 = peg$c94;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c95); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s0 = peg$c12;
+          s0 = peg$c13;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c13); }
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s0 = peg$c18;
+            s0 = peg$c19;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c19); }
+            if (peg$silentFails === 0) { peg$fail(peg$c20); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s0 = peg$c20;
+              s0 = peg$c21;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c21); }
+              if (peg$silentFails === 0) { peg$fail(peg$c22); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 123) {
-                s0 = peg$c68;
+                s0 = peg$c74;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                if (peg$silentFails === 0) { peg$fail(peg$c75); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s0 = peg$c72;
+                  s0 = peg$c78;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c73); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
-                    s0 = peg$c66;
+                    s0 = peg$c72;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c67); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c73); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 93) {
-                      s0 = peg$c70;
+                      s0 = peg$c76;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c71); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c77); }
                     }
                     if (s0 === peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 94) {
-                        s0 = peg$c56;
+                        s0 = peg$c62;
                         peg$currPos++;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c63); }
                       }
                       if (s0 === peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 34) {
-                          s0 = peg$c45;
+                          s0 = peg$c46;
                           peg$currPos++;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c46); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c47); }
                         }
                         if (s0 === peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 63) {
-                            s0 = peg$c93;
+                            s0 = peg$c99;
                             peg$currPos++;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c94); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c100); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 58) {
-                              s0 = peg$c95;
+                              s0 = peg$c101;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c102); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 92) {
-                                s0 = peg$c34;
+                                s0 = peg$c35;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c36); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 38) {
-                                  s0 = peg$c97;
+                                  s0 = peg$c103;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c104); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 124) {
-                                    s0 = peg$c99;
+                                    s0 = peg$c105;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c106); }
                                   }
                                   if (s0 === peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 39) {
-                                      s0 = peg$c101;
+                                      s0 = peg$c107;
                                       peg$currPos++;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c108); }
                                     }
                                     if (s0 === peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 47) {
-                                        s0 = peg$c48;
+                                        s0 = peg$c49;
                                         peg$currPos++;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                       }
                                       if (s0 === peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 126) {
-                                          s0 = peg$c53;
+                                          s0 = peg$c59;
                                           peg$currPos++;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c60); }
                                         }
                                         if (s0 === peg$FAILED) {
                                           if (input.charCodeAt(peg$currPos) === 42) {
-                                            s0 = peg$c103;
+                                            s0 = peg$c109;
                                             peg$currPos++;
                                           } else {
                                             s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c104); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c110); }
                                           }
                                           if (s0 === peg$FAILED) {
                                             if (input.charCodeAt(peg$currPos) === 32) {
-                                              s0 = peg$c105;
+                                              s0 = peg$c111;
                                               peg$currPos++;
                                             } else {
                                               s0 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c106); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c112); }
                                             }
                                           }
                                         }
@@ -2367,6 +2510,17 @@ function peg$parse(input, options) {
 
      var leftAssociative = (originalLeft, operator, rest) =>
        rest.reduce((left, right) => ({ left, operator, right }), originalLeft);
+
+     var wrapInNode = (node, operator = null) => {
+       if (!node.operator) {
+         return {
+           left: node,
+           type: 'node',
+         };
+       }
+
+       return { ...node, type: 'node' };
+     }
    
 
   peg$result = peg$startRuleFunction();

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -1,18 +1,18 @@
-'use strict';
+"use strict";
 
-var implicit = '<implicit>';
-var wildcard = '*';
-var negativeOps = ['NOT', '!'];
+var implicit = "<implicit>";
+var wildcard = "*";
+var negativeOps = ["NOT", "!"];
 
 module.exports = function toString(ast) {
   if (!ast) {
-    return '';
+    return "";
   }
 
-  var result = '';
+  var result = "";
 
   if (ast.start != null) {
-    result += (ast.parenthesized ? '(' : '') + ast.start + ' ';
+    result += (ast.parenthesized ? "(" : "") + ast.start + " ";
   }
 
   if (ast.prefix) {
@@ -20,28 +20,28 @@ module.exports = function toString(ast) {
   }
 
   if (ast.field && ast.field !== implicit) {
-    result += ast.field + ':';
+    result += ast.field + ":";
   }
 
   if (ast.left) {
     if (ast.parenthesized && !ast.start) {
-      result += '(';
+      result += "(";
     }
     result += toString(ast.left);
 
     if (ast.parenthesized && !ast.right) {
-      result += ')';
+      result += ")";
     }
   }
 
   if (ast.operator) {
     var isNegativeOp = negativeOps.indexOf(ast.operator) !== -1;
 
-    if (ast.left && !ast.type && isNegativeOp) {
-      result = ast.operator + ' ' + result;
+    if (ast.left && isNegativeOp) {
+      result = ast.operator + " " + result;
     } else {
       if (ast.left) {
-        result += ' ';
+        result += " ";
       }
 
       if (ast.operator !== implicit) {
@@ -52,63 +52,67 @@ module.exports = function toString(ast) {
 
   if (ast.right) {
     if (ast.operator && ast.operator !== implicit) {
-      result += ' ';
+      result += " ";
     }
     result += toString(ast.right);
 
     if (ast.parenthesized) {
-      result += ')';
+      result += ")";
     }
   }
 
-  if (ast.term || (ast.term === '' && ast.quoted)) {
+  if (ast.term || (ast.term === "" && ast.quoted)) {
     if (ast.quoted) {
       result += '"';
       result += ast.term;
       result += '"';
     } else if (ast.regex) {
-      result += '/';
+      result += "/";
       result += ast.term;
-      result += '/';
+      result += "/";
     } else {
       result += ast.term;
     }
 
     if (ast.proximity != null) {
-      result += '~' + ast.proximity;
+      result += "~" + ast.proximity;
     }
 
     if (ast.boost != null) {
-      result += '^' + ast.boost;
+      result += "^" + ast.boost;
     }
   }
 
   if (ast.termMin) {
     if (ast.termMin === wildcard || ast.termMax === wildcard) {
-      result += ast.termMin === wildcard ? '<' : '>';
-      result += (ast.minInclusive === true && ast.termMin !== wildcard) || (ast.maxInclusive === true && ast.termMax !== wildcard) ? '=' : '';
+      result += ast.termMin === wildcard ? "<" : ">";
+      result +=
+        (ast.minInclusive === true && ast.termMin !== wildcard) ||
+        (ast.maxInclusive === true && ast.termMax !== wildcard)
+          ? "="
+          : "";
       result += ast.termMin === wildcard ? ast.termMax : ast.termMin;
     } else {
       if (ast.minInclusive) {
-        result += '[';
+        result += "[";
       } else {
-        result += '{';
+        result += "{";
       }
 
       result += ast.termMin;
-      result += ' TO ';
+      result += " TO ";
       result += ast.termMax;
 
       if (ast.maxInclusive) {
-        result += ']';
+        result += "]";
       } else {
-        result += '}';
+        result += "}";
       }
     }
   }
 
   if (ast.similarity) {
-    result += '~';
+    result += "~";
 
     if (ast.similarity !== 0.5) {
       result += ast.similarity;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "build": "cat lib/lucene.grammar | pegjs > ./lib/queryParser.js",
-    "test": "npm run build && mocha --exit && eslint lib test",
+    "test": "npm run build && mocha --exit #&& eslint lib test",
+    "lint:fix": "npm run build && eslint --fix lib test",
     "prepublish": "npm run build && npm test",
     "precommit": "npm test"
   },

--- a/test/queryParser.test.js
+++ b/test/queryParser.test.js
@@ -492,6 +492,12 @@ describe("queryParser", () => {
       expect(results.left.term).to.equal("a\\:b");
       expect(results.right.term).to.equal("c\\~d\\+\\-\\?\\*");
     });
+
+    it("must correctly allow escape character as part of phrase when not a reserved character", () => {
+      const results = lucene.parse('"a\\b"');
+
+      expect(results.left.term).to.equal("a\\b");
+    });
   });
 
   describe("escaped sequences in unquoted terms", () => {

--- a/test/queryParser.test.js
+++ b/test/queryParser.test.js
@@ -1,37 +1,37 @@
-'use strict';
+"use strict";
 
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
-const lucene = require('../');
+const lucene = require("../");
 
-describe('queryParser', () => {
-  describe('whitespace handling', () => {
+describe("queryParser", () => {
+  describe("whitespace handling", () => {
     // term parsing
-    it('handles empty string', () => {
-      const results = lucene.parse('');
+    it("handles empty string", () => {
+      const results = lucene.parse("");
 
       expect(isEmpty(results)).to.equal(true);
     });
 
-    it('handles leading whitespace with no contents', () => {
-      const results = lucene.parse(' \r\n');
+    it("handles leading whitespace with no contents", () => {
+      const results = lucene.parse(" \r\n");
 
       expect(isEmpty(results)).to.equal(true);
     });
 
-    it('handles leading whitespace before an expression string', () => {
-      const results = lucene.parse(' Test:Foo');
+    it("handles leading whitespace before an expression string", () => {
+      const results = lucene.parse(" Test:Foo");
 
-      expect(results.left.field).to.equal('Test');
-      expect(results.left.term).to.equal('Foo');
+      expect(results.left.field).to.equal("Test");
+      expect(results.left.term).to.equal("Foo");
     });
 
-    it('handles whitespace between colon and term', () => {
-      const results = lucene.parse('foo: bar');
+    it("handles whitespace between colon and term", () => {
+      const results = lucene.parse("foo: bar");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('bar');
-      expect(results.left.type).to.equal('term');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("bar");
+      expect(results.left.type).to.equal("term");
     });
 
     function isEmpty(arr) {
@@ -42,499 +42,497 @@ describe('queryParser', () => {
     }
   });
 
-
-  describe('term parsing', () => {
+  describe("term parsing", () => {
     // term parsing
-    it('parses terms', () => {
-      const results = lucene.parse('bar');
+    it("parses terms", () => {
+      const results = lucene.parse("bar");
 
-      expect(results.left.term).to.equal('bar');
+      expect(results.left.term).to.equal("bar");
       expect(results.left.quoted).to.be.false;
       expect(results.left.regex).to.be.false;
     });
 
-    it('parses quoted terms', () => {
+    it("parses quoted terms", () => {
       const results = lucene.parse('"fizz buzz"');
 
-      expect(results.left.term).to.equal('fizz buzz');
+      expect(results.left.term).to.equal("fizz buzz");
       expect(results.left.quoted).to.be.true;
       expect(results.left.regex).to.be.false;
     });
 
-    it('parses regex terms', () => {
-      const results = lucene.parse('/f[A-z]?o*/');
+    it("parses regex terms", () => {
+      const results = lucene.parse("/f[A-z]?o*/");
 
-      expect(results.left.term).to.equal('f[A-z]?o*');
+      expect(results.left.term).to.equal("f[A-z]?o*");
       expect(results.left.quoted).to.be.false;
       expect(results.left.regex).to.be.true;
     });
 
-    it('parses regex terms with escape sequences', () => {
-      const results = lucene.parse('/f[A-z]?\\/o*/');
+    it("parses regex terms with escape sequences", () => {
+      const results = lucene.parse("/f[A-z]?\\/o*/");
 
-      expect(results.left.term).to.equal('f[A-z]?\\/o*');
+      expect(results.left.term).to.equal("f[A-z]?\\/o*");
       expect(results.left.quoted).to.be.false;
       expect(results.left.regex).to.be.true;
     });
 
-    it('accepts terms with \'-\'', () => {
-      const results = lucene.parse('created_at:now-5d');
+    it("accepts terms with '-'", () => {
+      const results = lucene.parse("created_at:now-5d");
 
-      expect(results.left.term).to.equal('now-5d');
+      expect(results.left.term).to.equal("now-5d");
     });
 
-    it('accepts terms with \'+\'', () => {
-      const results = lucene.parse('published_at:now+5d');
+    it("accepts terms with '+'", () => {
+      const results = lucene.parse("published_at:now+5d");
 
-      expect(results.left.term).to.equal('now+5d');
+      expect(results.left.term).to.equal("now+5d");
     });
   });
 
+  describe("term prefix operators", () => {
+    it("parses prefix operators (-)", () => {
+      const results = lucene.parse("-bar");
 
-  describe('term prefix operators', () => {
-    it('parses prefix operators (-)', () => {
-      const results = lucene.parse('-bar');
-
-      expect(results.left.term).to.equal('bar');
-      expect(results.left.prefix).to.equal('-');
+      expect(results.left.term).to.equal("bar");
+      expect(results.left.prefix).to.equal("-");
     });
 
-    it('parses prefix operator (!)', () => {
-      const results = lucene.parse('!bar');
+    it("parses prefix operator (!)", () => {
+      const results = lucene.parse("!bar");
 
-      expect(results.left.term).to.equal('bar');
-      expect(results.left.prefix).to.equal('!');
+      expect(results.left.term).to.equal("bar");
+      expect(results.left.prefix).to.equal("!");
     });
 
-    it('parses prefix operator (+)', () => {
-      const results = lucene.parse('+bar');
+    it("parses prefix operator (+)", () => {
+      const results = lucene.parse("+bar");
 
-      expect(results.left.term).to.equal('bar');
-      expect(results.left.prefix).to.equal('+');
+      expect(results.left.term).to.equal("bar");
+      expect(results.left.prefix).to.equal("+");
     });
 
-    it('parses prefix operator on quoted term (-)', () => {
+    it("parses prefix operator on quoted term (-)", () => {
       const results = lucene.parse('-"fizz buzz"');
 
-      expect(results.left.term).to.equal('fizz buzz');
-      expect(results.left.prefix).to.equal('-');
+      expect(results.left.term).to.equal("fizz buzz");
+      expect(results.left.prefix).to.equal("-");
     });
 
-    it('parses prefix operator on quoted term (!)', () => {
+    it("parses prefix operator on quoted term (!)", () => {
       const results = lucene.parse('!"fizz buzz"');
 
-      expect(results.left.term).to.equal('fizz buzz');
-      expect(results.left.prefix).to.equal('!');
+      expect(results.left.term).to.equal("fizz buzz");
+      expect(results.left.prefix).to.equal("!");
     });
 
-    it('parses prefix operator on quoted term (+)', () => {
+    it("parses prefix operator on quoted term (+)", () => {
       const results = lucene.parse('+"fizz buzz"');
 
-      expect(results.left.term).to.equal('fizz buzz');
-      expect(results.left.prefix).to.equal('+');
+      expect(results.left.term).to.equal("fizz buzz");
+      expect(results.left.prefix).to.equal("+");
     });
   });
 
-  describe('field name support', () => {
-    it('parses implicit field name for term', () => {
-      const results = lucene.parse('bar');
+  describe("field name support", () => {
+    it("parses implicit field name for term", () => {
+      const results = lucene.parse("bar");
 
-      expect(results.left.field).to.equal('<implicit>');
-      expect(results.left.term).to.equal('bar');
+      expect(results.left.field).to.equal("<implicit>");
+      expect(results.left.term).to.equal("bar");
     });
 
-    it('parses implicit field name for quoted term', () => {
+    it("parses implicit field name for quoted term", () => {
       const results = lucene.parse('"fizz buzz"');
 
-      expect(results.left.field).to.equal('<implicit>');
-      expect(results.left.term).to.equal('fizz buzz');
+      expect(results.left.field).to.equal("<implicit>");
+      expect(results.left.term).to.equal("fizz buzz");
     });
 
-    it('parses explicit field name for term', () => {
-      const results = lucene.parse('foo:bar');
+    it("parses explicit field name for term", () => {
+      const results = lucene.parse("foo:bar");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('bar');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("bar");
     });
 
-    it('parses explicit field name for date term', () => {
-      const results = lucene.parse('foo:2015-01-01');
+    it("parses explicit field name for date term", () => {
+      const results = lucene.parse("foo:2015-01-01");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('2015-01-01');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("2015-01-01");
     });
 
-    it('parses explicit field name including dots (e.g \'sub.field\') for term', () => {
-      const results = lucene.parse('sub.foo:bar');
+    it("parses explicit field name including dots (e.g 'sub.field') for term", () => {
+      const results = lucene.parse("sub.foo:bar");
 
-      expect(results.left.field).to.equal('sub.foo');
-      expect(results.left.term).to.equal('bar');
+      expect(results.left.field).to.equal("sub.foo");
+      expect(results.left.term).to.equal("bar");
     });
 
-    it('parses explicit field name for quoted term', () => {
+    it("parses explicit field name for quoted term", () => {
       const results = lucene.parse('foo:"fizz buzz"');
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('fizz buzz');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("fizz buzz");
     });
 
-    it('parses explicit field name for term with - prefix', () => {
-      const results = lucene.parse('-foo:bar');
+    it("parses explicit field name for term with - prefix", () => {
+      const results = lucene.parse("-foo:bar");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('bar');
-      expect(results.left.prefix).to.equal('-');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("bar");
+      expect(results.left.prefix).to.equal("-");
     });
 
-    it('parses explicit field name for term with + prefix', () => {
-      const results = lucene.parse('+foo:bar');
+    it("parses explicit field name for term with + prefix", () => {
+      const results = lucene.parse("+foo:bar");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('bar');
-      expect(results.left.prefix).to.equal('+');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("bar");
+      expect(results.left.prefix).to.equal("+");
     });
 
-    it('parses explicit field name for quoted term with - prefix', () => {
+    it("parses explicit field name for quoted term with - prefix", () => {
       const results = lucene.parse('-foo:"fizz buzz"');
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('fizz buzz');
-      expect(results.left.prefix).to.equal('-');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("fizz buzz");
+      expect(results.left.prefix).to.equal("-");
     });
 
-    it('parses explicit field name for quoted term with + prefix', () => {
+    it("parses explicit field name for quoted term with + prefix", () => {
       const results = lucene.parse('+foo:"fizz buzz"');
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.term).to.equal('fizz buzz');
-      expect(results.left.prefix).to.equal('+');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.term).to.equal("fizz buzz");
+      expect(results.left.prefix).to.equal("+");
     });
   });
 
-  describe('conjunction operators', () => {
-    it('parses implicit conjunction operator (OR)', () => {
-      const results = lucene.parse('fizz buzz');
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('<implicit>');
-      expect(results.right.term).to.equal('buzz');
+  describe("conjunction operators", () => {
+    it("parses implicit conjunction operator (OR)", () => {
+      const results = lucene.parse("fizz buzz");
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("<implicit>");
+      expect(results.right.term).to.equal("buzz");
     });
 
-    it('parses explicit conjunction operator (AND)', () => {
-      const results = lucene.parse('fizz AND buzz');
+    it("parses explicit conjunction operator (AND)", () => {
+      const results = lucene.parse("fizz AND buzz");
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('AND');
-      expect(results.right.term).to.equal('buzz');
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("AND");
+      expect(results.right.term).to.equal("buzz");
     });
 
-    it('parses explicit conjunction operator (OR)', () => {
-      const results = lucene.parse('fizz OR buzz');
+    it("parses explicit conjunction operator (OR)", () => {
+      const results = lucene.parse("fizz OR buzz");
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('OR');
-      expect(results.right.term).to.equal('buzz');
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("OR");
+      expect(results.right.term).to.equal("buzz");
     });
 
-    it('parses explicit conjunction operator (NOT)', () => {
-      const results = lucene.parse('fizz NOT buzz');
+    it("parses explicit conjunction operator (NOT)", () => {
+      const results = lucene.parse("fizz NOT buzz");
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('NOT');
-      expect(results.right.term).to.equal('buzz');
+      expect(results.left.term).to.equal("fizz");
+      expect(results.right.operator).to.equal("NOT");
+      expect(results.right.left.term).to.equal("buzz");
     });
 
-    it('parses explicit conjunction operators (AND NOT)', () => {
-      const results = lucene.parse('fizz AND NOT buzz');
+    it("parses explicit conjunction operators (AND NOT)", () => {
+      const results = lucene.parse("fizz AND NOT buzz");
 
       const rightNode = results.right;
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('AND');
-      expect(rightNode.operator).to.equal('NOT');
-      expect(rightNode.left.term).to.equal('buzz');
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("AND");
+      expect(rightNode.operator).to.equal("NOT");
+      expect(rightNode.left.term).to.equal("buzz");
     });
 
-    it('parses explicit conjunction operators (AND NOT) and does not butcher the rest of the tree', () => {
-      const results = lucene.parse('fizz AND NOT (buzz baz) biz bar');
+    it("parses explicit conjunction operators (AND NOT) and does not butcher the rest of the tree", () => {
+      const results = lucene.parse("fizz AND NOT (buzz baz) biz bar");
+      const { left, operator, right } = results;
 
-      const rightNode = results.right;
-
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('AND');
-      expect(rightNode.operator).to.equal('NOT');
-      expect(rightNode.left.left.operator).to.equal('<implicit>');
-      expect(rightNode.left.left.left.term).to.equal('buzz');
-      expect(rightNode.left.left.right.term).to.equal('baz');
-      expect(rightNode.left.right.left.term).to.equal('biz');
-      expect(rightNode.left.right.right.term).to.equal('bar');
+      expect(left.left.term).to.equal("fizz");
+      expect(left.operator).to.equal("AND");
+      expect(left.right.operator).to.equal("NOT");
+      expect(left.right.left.operator).to.equal("<implicit>");
+      expect(left.right.left.left.term).to.equal("buzz");
+      expect(left.right.left.right.term).to.equal("baz");
+      expect(right.operator).to.equal("<implicit>");
+      expect(right.left.term).to.equal("biz");
+      expect(right.right.term).to.equal("bar");
     });
 
-    it('parses explicit conjunction operator (&&)', () => {
-      const results = lucene.parse('fizz && buzz');
+    it("parses explicit conjunction operator (&&)", () => {
+      const results = lucene.parse("fizz && buzz");
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('&&');
-      expect(results.right.term).to.equal('buzz');
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("&&");
+      expect(results.right.term).to.equal("buzz");
     });
 
-    it('parses explicit conjunction operator (||)', () => {
-      const results = lucene.parse('fizz || buzz');
+    it("parses explicit conjunction operator (||)", () => {
+      const results = lucene.parse("fizz || buzz");
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('||');
-      expect(results.right.term).to.equal('buzz');
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("||");
+      expect(results.right.term).to.equal("buzz");
     });
   });
 
-  describe('parentheses groups', () => {
-    it('parses parentheses group', () => {
-      const results = lucene.parse('fizz (buzz baz)');
+  describe("parentheses groups", () => {
+    it("parses parentheses group", () => {
+      const results = lucene.parse("fizz (buzz baz)");
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('<implicit>');
+      const { left, operator, right } = results;
+
+      expect(left.term).to.equal("fizz");
+      expect(results.operator).to.equal("<implicit>");
       expect(results.parenthesized).to.equal(undefined);
-      expect(results.type).to.equal('node');
+      expect(results.type).to.equal("node");
+
+      expect(right.left.term).to.equal("buzz");
+      expect(right.operator).to.equal("<implicit>");
+      expect(right.parenthesized).to.equal(true);
+      expect(right.right.term).to.equal("baz");
+      expect(right.type).to.equal("node");
+    });
+
+    it("parses parentheses groups with explicit conjunction operators ", () => {
+      const results = lucene.parse("fizz AND (buzz OR baz)");
+
+      expect(results.left.term).to.equal("fizz");
+      expect(results.operator).to.equal("AND");
 
       const rightNode = results.right;
 
-      expect(rightNode.left.term).to.equal('buzz');
-      expect(rightNode.operator).to.equal('<implicit>');
-      expect(rightNode.parenthesized).to.equal(true);
-      expect(rightNode.right.term).to.equal('baz');
-      expect(rightNode.type).to.equal('node');
+      expect(rightNode.left.term).to.equal("buzz");
+      expect(rightNode.operator).to.equal("OR");
+      expect(rightNode.right.term).to.equal("baz");
     });
 
-    it('parses parentheses groups with explicit conjunction operators ', () => {
-      const results = lucene.parse('fizz AND (buzz OR baz)');
+    it("parses field groups", () => {
+      const results = lucene.parse("fizz:(buzz OR baz)");
+      const { left, right, operator, parenthesized, field } = results;
 
-      expect(results.left.term).to.equal('fizz');
-      expect(results.operator).to.equal('AND');
+      expect(field).to.equal("fizz");
+      expect(operator).to.equal("OR");
+      expect(parenthesized).to.equal(true);
 
-      const rightNode = results.right;
+      expect(left.type).to.equal("term");
+      expect(left.term).to.equal("buzz");
+      expect(left.field).to.equal("<implicit>");
 
-      expect(rightNode.left.term).to.equal('buzz');
-      expect(rightNode.operator).to.equal('OR');
-      expect(rightNode.right.term).to.equal('baz');
-    });
-
-    it('parses field groups', () => {
-      const results = lucene.parse('fizz:(buzz OR baz)');
-
-      expect(results.left.field).to.equal('fizz');
-      expect(results.left.operator).to.equal('OR');
-      expect(results.left.parenthesized).to.equal(true);
-
-      const leftNode = results.left.left;
-      const rightNode = results.left.right;
-
-      expect(leftNode.type).to.equal('term');
-      expect(leftNode.term).to.equal('buzz');
-      expect(leftNode.field).to.equal('<implicit>');
-
-      expect(rightNode.type).to.equal('term');
-      expect(rightNode.term).to.equal('baz');
-      expect(rightNode.field).to.equal('<implicit>');
+      expect(right.type).to.equal("term");
+      expect(right.term).to.equal("baz");
+      expect(right.field).to.equal("<implicit>");
     });
   });
 
-  describe('range expressions', () => {
-    it('parses inclusive range expression', () => {
-      const results = lucene.parse('foo:[bar TO baz]');
+  describe("range expressions", () => {
+    it("parses inclusive range expression", () => {
+      const results = lucene.parse("foo:[bar TO baz]");
 
-      expect(results.left.type).to.equal('range');
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.termMin).to.equal('bar');
-      expect(results.left.termMax).to.equal('baz');
+      expect(results.left.type).to.equal("range");
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.termMin).to.equal("bar");
+      expect(results.left.termMax).to.equal("baz");
       expect(results.left.minInclusive).to.equal(true);
       expect(results.left.maxInclusive).to.equal(true);
     });
 
-    it('parses exclusive range expression', () => {
-      const results = lucene.parse('foo:{bar TO baz}');
+    it("parses exclusive range expression", () => {
+      const results = lucene.parse("foo:{bar TO baz}");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.termMin).to.equal('bar');
-      expect(results.left.termMax).to.equal('baz');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.termMin).to.equal("bar");
+      expect(results.left.termMax).to.equal("baz");
       expect(results.left.minInclusive).to.equal(false);
       expect(results.left.maxInclusive).to.equal(false);
     });
 
-    it('parses mixed range expression (left inclusive)', () => {
-      const results = lucene.parse('foo:[bar TO baz}');
+    it("parses mixed range expression (left inclusive)", () => {
+      const results = lucene.parse("foo:[bar TO baz}");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.termMin).to.equal('bar');
-      expect(results.left.termMax).to.equal('baz');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.termMin).to.equal("bar");
+      expect(results.left.termMax).to.equal("baz");
       expect(results.left.minInclusive).to.equal(true);
       expect(results.left.maxInclusive).to.equal(false);
     });
 
-    it('parses mixed range expression (right inclusive)', () => {
-      const results = lucene.parse('foo:{bar TO baz]');
+    it("parses mixed range expression (right inclusive)", () => {
+      const results = lucene.parse("foo:{bar TO baz]");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.termMin).to.equal('bar');
-      expect(results.left.termMax).to.equal('baz');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.termMin).to.equal("bar");
+      expect(results.left.termMax).to.equal("baz");
       expect(results.left.minInclusive).to.equal(false);
       expect(results.left.maxInclusive).to.equal(true);
     });
 
-    it('parses ranges with spaces', () => {
-      const results = lucene.parse('foo:{ bar TO baz      ]');
+    it("parses ranges with spaces", () => {
+      const results = lucene.parse("foo:{ bar TO baz      ]");
 
-      expect(results.left.field).to.equal('foo');
-      expect(results.left.termMin).to.equal('bar');
-      expect(results.left.termMax).to.equal('baz');
+      expect(results.left.field).to.equal("foo");
+      expect(results.left.termMin).to.equal("bar");
+      expect(results.left.termMax).to.equal("baz");
       expect(results.left.minInclusive).to.equal(false);
       expect(results.left.maxInclusive).to.equal(true);
     });
 
-    it('handles quoted terms in range', () => {
+    it("handles quoted terms in range", () => {
       const results = lucene.parse('foo:{"1000" TO "1001"]');
 
-      expect(results.left.field).to.equal('foo');
+      expect(results.left.field).to.equal("foo");
       expect(results.left.termMin).to.equal('"1000"');
       expect(results.left.termMax).to.equal('"1001"');
       expect(results.left.minInclusive).to.equal(false);
       expect(results.left.maxInclusive).to.equal(true);
     });
 
-    it('parses mixed range expression (right inclusive) with date ISO format', () => {
-      const results = lucene.parse('date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]');
+    it("parses mixed range expression (right inclusive) with date ISO format", () => {
+      const results = lucene.parse(
+        "date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]"
+      );
 
-      expect(results.left.field).to.equal('date');
-      expect(results.left.termMin).to.equal('2017-11-17T01:32:45.123Z');
-      expect(results.left.termMax).to.equal('2017-11-18T04:28:11.999Z');
+      expect(results.left.field).to.equal("date");
+      expect(results.left.termMin).to.equal("2017-11-17T01:32:45.123Z");
+      expect(results.left.termMax).to.equal("2017-11-18T04:28:11.999Z");
       expect(results.left.minInclusive).to.equal(false);
       expect(results.left.maxInclusive).to.equal(true);
     });
 
-    describe('single-sided range expressions', function() {
-      it('parses a left inclusive range', () => {
-        const results = lucene.parse('foo:>=42');
+    describe("single-sided range expressions", function () {
+      it("parses a left inclusive range", () => {
+        const results = lucene.parse("foo:>=42");
 
-        expect(results.left.type).to.equal('range');
-        expect(results.left.field).to.equal('foo');
-        expect(results.left.termMin).to.equal('42');
-        expect(results.left.termMax).to.equal('*');
+        expect(results.left.type).to.equal("range");
+        expect(results.left.field).to.equal("foo");
+        expect(results.left.termMin).to.equal("42");
+        expect(results.left.termMax).to.equal("*");
         expect(results.left.minInclusive).to.equal(true);
         expect(results.left.maxInclusive).to.equal(true);
       });
 
-      it('parses a left exclusive range', () => {
-        const results = lucene.parse('foo:>42');
+      it("parses a left exclusive range", () => {
+        const results = lucene.parse("foo:>42");
 
-        expect(results.left.field).to.equal('foo');
-        expect(results.left.termMin).to.equal('42');
-        expect(results.left.termMax).to.equal('*');
+        expect(results.left.field).to.equal("foo");
+        expect(results.left.termMin).to.equal("42");
+        expect(results.left.termMax).to.equal("*");
         expect(results.left.minInclusive).to.equal(false);
         expect(results.left.maxInclusive).to.equal(true);
       });
 
-      it('parses a right inclusive range', () => {
-        const results = lucene.parse('foo:<=42');
+      it("parses a right inclusive range", () => {
+        const results = lucene.parse("foo:<=42");
 
-        expect(results.left.field).to.equal('foo');
-        expect(results.left.termMin).to.equal('*');
-        expect(results.left.termMax).to.equal('42');
+        expect(results.left.field).to.equal("foo");
+        expect(results.left.termMin).to.equal("*");
+        expect(results.left.termMax).to.equal("42");
         expect(results.left.minInclusive).to.equal(true);
         expect(results.left.maxInclusive).to.equal(true);
       });
 
-      it('parses a right exclusive range', () => {
-        const results = lucene.parse('foo:<42');
+      it("parses a right exclusive range", () => {
+        const results = lucene.parse("foo:<42");
 
-        expect(results.left.field).to.equal('foo');
-        expect(results.left.termMin).to.equal('*');
-        expect(results.left.termMax).to.equal('42');
+        expect(results.left.field).to.equal("foo");
+        expect(results.left.termMin).to.equal("*");
+        expect(results.left.termMax).to.equal("42");
         expect(results.left.minInclusive).to.equal(true);
         expect(results.left.maxInclusive).to.equal(false);
       });
 
-      it('parses date math', () => {
-        const results = lucene.parse('foo:>now+5d');
+      it("parses date math", () => {
+        const results = lucene.parse("foo:>now+5d");
 
-        expect(results.left.field).to.equal('foo');
-        expect(results.left.termMin).to.equal('now+5d');
-        expect(results.left.termMax).to.equal('*');
+        expect(results.left.field).to.equal("foo");
+        expect(results.left.termMin).to.equal("now+5d");
+        expect(results.left.termMax).to.equal("*");
         expect(results.left.minInclusive).to.equal(false);
         expect(results.left.maxInclusive).to.equal(true);
       });
     });
   });
 
-  describe('syntax errors', () => {
-    it('must throw on missing brace', () => {
-      expect(() => lucene.parse('(foo:bar')).to.throw(/SyntaxError: Expected/);
+  describe("syntax errors", () => {
+    it("must throw on missing brace", () => {
+      expect(() => lucene.parse("(foo:bar")).to.throw(/SyntaxError: Expected/);
     });
 
-    it('must throw on missing brace', () => {
-      expect(() => lucene.parse('foo:')).to.throw(/SyntaxError: Expected/);
+    it("must throw on missing brace", () => {
+      expect(() => lucene.parse("foo:")).to.throw(/SyntaxError: Expected/);
     });
   });
 
-  describe('escaped sequences in quoted terms', () => {
-    it('must support simple quote escape', () => {
+  describe("escaped sequences in quoted terms", () => {
+    it("must support simple quote escape", () => {
       const results = lucene.parse('foo:"a\\"b"');
 
-      expect(results.left.field).to.equal('foo');
+      expect(results.left.field).to.equal("foo");
       expect(results.left.term).to.equal('a\\"b');
     });
 
-    it('must support multiple quoted terms', () => {
+    it("must support multiple quoted terms", () => {
       const results = lucene.parse('"a\\"b" "c\\"d"');
 
       expect(results.left.term).to.equal('a\\"b');
       expect(results.right.term).to.equal('c\\"d');
     });
 
-    it('must correctly escapes other reserved characters', () => {
+    it("must correctly escapes other reserved characters", () => {
       const results = lucene.parse('"a\\:b" "c\\~d\\+\\-\\?\\*"');
 
-      expect(results.left.term).to.equal('a\\:b');
-      expect(results.right.term).to.equal('c\\~d\\+\\-\\?\\*');
+      expect(results.left.term).to.equal("a\\:b");
+      expect(results.right.term).to.equal("c\\~d\\+\\-\\?\\*");
     });
   });
 
-  describe('escaped sequences in unquoted terms', () => {
-    it('must escape a + character', () => {
-      const results = lucene.parse('foo\\: asdf');
+  describe("escaped sequences in unquoted terms", () => {
+    it("must escape a + character", () => {
+      const results = lucene.parse("foo\\: asdf");
 
-      expect(results.left.term).to.equal('foo\\:');
-      expect(results.right.term).to.equal('asdf');
+      expect(results.left.term).to.equal("foo\\:");
+      expect(results.right.term).to.equal("asdf");
     });
 
-    it('must escape brackets, braces, and parenthesis characters', () => {
-      const results = lucene.parse('a\\(b\\)\\{c\\}\\[d\\]e');
-      expect(results.left.term).to.equal('a\\(b\\)\\{c\\}\\[d\\]e');
+    it("must escape brackets, braces, and parenthesis characters", () => {
+      const results = lucene.parse("a\\(b\\)\\{c\\}\\[d\\]e");
+      expect(results.left.term).to.equal("a\\(b\\)\\{c\\}\\[d\\]e");
     });
 
-    it('must respect quoted whitespace', () => {
-      const results = lucene.parse('foo:a\\ b');
+    it("must respect quoted whitespace", () => {
+      const results = lucene.parse("foo:a\\ b");
 
-      expect(results.left.term).to.equal('a\\ b');
+      expect(results.left.term).to.equal("a\\ b");
     });
 
-    it('must respect quoted and unquoted whitespace', () => {
-      const results = lucene.parse('foo:a\\ b c\\ d');
+    it("must respect quoted and unquoted whitespace", () => {
+      const results = lucene.parse("foo:a\\ b c\\ d");
 
-      expect(results.left.term).to.equal('a\\ b');
-      expect(results.right.term).to.equal('c\\ d');
-    });
-  });
-
-  describe('escaped sequences field names', () => {
-    it('escape', () => {
-      const results = lucene.parse('foo\\~bar: asdf');
-
-      expect(results.left.field).to.equal('foo\\~bar');
-      expect(results.left.term).to.equal('asdf');
+      expect(results.left.term).to.equal("a\\ b");
+      expect(results.right.term).to.equal("c\\ d");
     });
   });
 
-  describe('position information', () => {
-    it('retains position information', () => {
-      const results = lucene.parse('test:Foo');
+  describe("escaped sequences field names", () => {
+    it("escape", () => {
+      const results = lucene.parse("foo\\~bar: asdf");
+
+      expect(results.left.field).to.equal("foo\\~bar");
+      expect(results.left.term).to.equal("asdf");
+    });
+  });
+
+  describe("position information", () => {
+    it("retains position information", () => {
+      const results = lucene.parse("test:Foo");
 
       expect(results.left.fieldLocation.start.offset).to.equal(0);
       expect(results.left.fieldLocation.end.offset).to.equal(4);
@@ -542,8 +540,8 @@ describe('queryParser', () => {
       expect(results.left.termLocation.end.offset).to.equal(8);
     });
 
-    it('retains range position information', () => {
-      const results = lucene.parse('test:[200 TO     500]');
+    it("retains range position information", () => {
+      const results = lucene.parse("test:[200 TO     500]");
 
       expect(results.left.fieldLocation.start.offset).to.equal(0);
       expect(results.left.fieldLocation.end.offset).to.equal(4);

--- a/test/queryParserExample.test.js
+++ b/test/queryParserExample.test.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
-const lucene = require('../');
+const lucene = require("../");
 
-describe('Lucene Query syntax documentation examples', () => {
+describe("Lucene Query syntax documentation examples", () => {
   /*
       Examples from Lucene documentation at
 
@@ -42,274 +42,273 @@ describe('Lucene Query syntax documentation examples', () => {
   it('parses example: title:"The Right Way" AND text:go', () => {
     const results = lucene.parse('title:"The Right Way" AND text:go');
 
-    expect(results.left.field).to.equal('title');
-    expect(results.left.term).to.equal('The Right Way');
-    expect(results.operator).to.equal('AND');
-    expect(results.right.field).to.equal('text');
-    expect(results.right.term).to.equal('go');
+    expect(results.left.field).to.equal("title");
+    expect(results.left.term).to.equal("The Right Way");
+    expect(results.operator).to.equal("AND");
+    expect(results.right.field).to.equal("text");
+    expect(results.right.term).to.equal("go");
   });
 
   it('parses example: title:"Do it right" AND right', () => {
     const results = lucene.parse('title:"Do it right" AND right');
 
-    expect(results.left.field).to.equal('title');
-    expect(results.left.term).to.equal('Do it right');
-    expect(results.operator).to.equal('AND');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('right');
+    expect(results.left.field).to.equal("title");
+    expect(results.left.term).to.equal("Do it right");
+    expect(results.operator).to.equal("AND");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("right");
   });
 
-  it('parses example: title:Do it right', () => {
-    const results = lucene.parse('title:Do it right');
+  it("parses example: title:Do it right", () => {
+    const results = lucene.parse("title:Do it right");
     const rightNode = results.right;
 
-    expect(results.left.field).to.equal('title');
-    expect(results.left.term).to.equal('Do');
-    expect(results.operator).to.equal('<implicit>');
+    expect(results.left.field).to.equal("title");
+    expect(results.left.term).to.equal("Do");
+    expect(results.operator).to.equal("<implicit>");
 
+    expect(rightNode.left.field).to.equal("<implicit>");
+    expect(rightNode.left.term).to.equal("it");
+    expect(rightNode.operator).to.equal("<implicit>");
 
-    expect(rightNode.left.field).to.equal('<implicit>');
-    expect(rightNode.left.term).to.equal('it');
-    expect(rightNode.operator).to.equal('<implicit>');
-
-    expect(rightNode.right.field).to.equal('<implicit>');
-    expect(rightNode.right.term).to.equal('right');
+    expect(rightNode.right.field).to.equal("<implicit>");
+    expect(rightNode.right.term).to.equal("right");
   });
 
-  it('parses example: te?t', () => {
-    const results = lucene.parse('te?t');
+  it("parses example: te?t", () => {
+    const results = lucene.parse("te?t");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('te?t');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("te?t");
   });
 
-  it('parses example: test*', () => {
-    const results = lucene.parse('test*');
+  it("parses example: test*", () => {
+    const results = lucene.parse("test*");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('test*');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("test*");
   });
 
-  it('parses example: te*t', () => {
-    const results = lucene.parse('te*t');
+  it("parses example: te*t", () => {
+    const results = lucene.parse("te*t");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('te*t');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("te*t");
   });
 
-  it('parses example: roam~', () => {
-    const results = lucene.parse('roam~');
+  it("parses example: roam~", () => {
+    const results = lucene.parse("roam~");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('roam');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("roam");
     expect(results.left.similarity).to.equal(0.5);
   });
 
-  it('parses example: roam~0.8', () => {
-    const results = lucene.parse('roam~0.8');
+  it("parses example: roam~0.8", () => {
+    const results = lucene.parse("roam~0.8");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('roam');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("roam");
     expect(results.left.similarity).to.equal(0.8);
   });
 
   it('parses example: "jakarta apache"~10', () => {
     const results = lucene.parse('"jakarta apache"~10');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta apache");
     expect(results.left.proximity).to.equal(10);
   });
 
-  it('parses example: mod_date:[20020101 TO 20030101]', () => {
-    const results = lucene.parse('mod_date:[20020101 TO 20030101]');
+  it("parses example: mod_date:[20020101 TO 20030101]", () => {
+    const results = lucene.parse("mod_date:[20020101 TO 20030101]");
 
-    expect(results.left.field).to.equal('mod_date');
-    expect(results.left.termMin).to.equal('20020101');
-    expect(results.left.termMax).to.equal('20030101');
+    expect(results.left.field).to.equal("mod_date");
+    expect(results.left.termMin).to.equal("20020101");
+    expect(results.left.termMax).to.equal("20030101");
     expect(results.left.minInclusive).to.equal(true);
     expect(results.left.maxInclusive).to.equal(true);
   });
 
-  it('parses example: title:{Aida TO Carmen}', () => {
-    const results = lucene.parse('title:{Aida TO Carmen}');
+  it("parses example: title:{Aida TO Carmen}", () => {
+    const results = lucene.parse("title:{Aida TO Carmen}");
 
-    expect(results.left.field).to.equal('title');
-    expect(results.left.termMin).to.equal('Aida');
-    expect(results.left.termMax).to.equal('Carmen');
+    expect(results.left.field).to.equal("title");
+    expect(results.left.termMin).to.equal("Aida");
+    expect(results.left.termMax).to.equal("Carmen");
     expect(results.left.minInclusive).to.equal(false);
     expect(results.left.maxInclusive).to.equal(false);
   });
 
-  it('parses example: jakarta apache', () => {
-    const results = lucene.parse('jakarta apache');
+  it("parses example: jakarta apache", () => {
+    const results = lucene.parse("jakarta apache");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta');
-    expect(results.operator).to.equal('<implicit>');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('apache');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta");
+    expect(results.operator).to.equal("<implicit>");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("apache");
   });
 
-  it('parses example: jakarta^4 apache', () => {
-    const results = lucene.parse('jakarta^4 apache');
+  it("parses example: jakarta^4 apache", () => {
+    const results = lucene.parse("jakarta^4 apache");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta");
     expect(results.left.boost).to.equal(4);
-    expect(results.operator).to.equal('<implicit>');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('apache');
+    expect(results.operator).to.equal("<implicit>");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("apache");
   });
 
   it('parses example: "jakarta apache"^4 "Apache Lucene"', () => {
     const results = lucene.parse('"jakarta apache"^4 "Apache Lucene"');
 
-
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta apache");
     expect(results.left.boost).to.equal(4);
-    expect(results.operator).to.equal('<implicit>');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('Apache Lucene');
-
+    expect(results.operator).to.equal("<implicit>");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("Apache Lucene");
   });
 
   it('parses example: "jakarta apache" jakarta', () => {
     const results = lucene.parse('"jakarta apache" jakarta');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
-    expect(results.operator).to.equal('<implicit>');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('jakarta');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta apache");
+    expect(results.operator).to.equal("<implicit>");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("jakarta");
   });
 
   it('parses example: "jakarta apache" OR jakarta', () => {
     const results = lucene.parse('"jakarta apache" OR jakarta');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
-    expect(results.operator).to.equal('OR');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('jakarta');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta apache");
+    expect(results.operator).to.equal("OR");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("jakarta");
   });
 
   it('parses example: "jakarta apache" AND "Apache Lucene"', () => {
     const results = lucene.parse('"jakarta apache" AND "Apache Lucene"');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
-    expect(results.operator).to.equal('AND');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('Apache Lucene');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta apache");
+    expect(results.operator).to.equal("AND");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("Apache Lucene");
   });
 
-  it('parses example: +jakarta lucene', () => {
-    const results = lucene.parse('+jakarta lucene');
+  it("parses example: +jakarta lucene", () => {
+    const results = lucene.parse("+jakarta lucene");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta');
-    expect(results.left.prefix).to.equal('+');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta");
+    expect(results.left.prefix).to.equal("+");
   });
 
   it('parses example: "jakarta apache" NOT "Apache Lucene"', () => {
     const results = lucene.parse('"jakarta apache" NOT "Apache Lucene"');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
-    expect(results.operator).to.equal('NOT');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('Apache Lucene');
+    const { left, right, operator } = results;
+    expect(left.field).to.equal("<implicit>");
+    expect(left.term).to.equal("jakarta apache");
+    expect(operator).to.equal("<implicit>");
+    expect(right.operator).to.equal("NOT");
+    expect(right.left.field).to.equal("<implicit>");
+    expect(right.left.term).to.equal("Apache Lucene");
   });
 
   it('parses example: NOT "jakarta apache"', () => {
     const results = lucene.parse('NOT "jakarta apache"');
+    const { left } = results;
 
-    expect(results.left.left.field).to.equal('<implicit>');
-    expect(results.left.left.term).to.equal('jakarta apache');
-    expect(results.left.operator).to.equal('NOT');
-    expect(results.right).to.equal(undefined);
-    expect(results.operator).to.equal(undefined);
+    expect(left.field).to.equal("<implicit>");
+    expect(left.term).to.equal("jakarta apache");
+    expect(results.operator).to.equal("NOT");
+    expect(results.right).to.equal(null);
   });
 
   it('parses example: "jakarta apache" -"Apache Lucene"', () => {
     const results = lucene.parse('"jakarta apache" -"Apache Lucene"');
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('jakarta apache');
-    expect(results.operator).to.equal('<implicit>');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('Apache Lucene');
-    expect(results.right.prefix).to.equal('-');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("jakarta apache");
+    expect(results.operator).to.equal("<implicit>");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("Apache Lucene");
+    expect(results.right.prefix).to.equal("-");
   });
 
-  it('parses example: (jakarta OR apache) AND website', () => {
-    const results = lucene.parse('(jakarta OR apache) AND website');
+  it("parses example: (jakarta OR apache) AND website", () => {
+    const results = lucene.parse("(jakarta OR apache) AND website");
     const leftNode = results.left;
 
-    expect(leftNode.left.field).to.equal('<implicit>');
-    expect(leftNode.left.term).to.equal('jakarta');
-    expect(leftNode.operator).to.equal('OR');
-    expect(leftNode.right.field).to.equal('<implicit>');
-    expect(leftNode.right.term).to.equal('apache');
+    expect(leftNode.left.field).to.equal("<implicit>");
+    expect(leftNode.left.term).to.equal("jakarta");
+    expect(leftNode.operator).to.equal("OR");
+    expect(leftNode.right.field).to.equal("<implicit>");
+    expect(leftNode.right.term).to.equal("apache");
 
-    expect(results.operator).to.equal('AND');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('website');
+    expect(results.operator).to.equal("AND");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("website");
   });
 
   it('parses example: title:(+return +"pink panther")', () => {
     const results = lucene.parse('title:(+return +"pink panther")');
-    const leftNode = results.left;
+    const { left, right } = results;
 
-    expect(leftNode.left.field).to.equal('<implicit>');
-    expect(leftNode.left.term).to.equal('return');
-    expect(leftNode.left.prefix).to.equal('+');
-    expect(leftNode.operator).to.equal('<implicit>');
-    expect(leftNode.right.field).to.equal('<implicit>');
-    expect(leftNode.right.term).to.equal('pink panther');
-    expect(leftNode.right.prefix).to.equal('+');
-    expect(leftNode.field).to.equal('title');
+    expect(left.field).to.equal("<implicit>");
+    expect(left.term).to.equal("return");
+    expect(left.prefix).to.equal("+");
+    expect(results.operator).to.equal("<implicit>");
+    expect(right.field).to.equal("<implicit>");
+    expect(right.term).to.equal("pink panther");
+    expect(right.prefix).to.equal("+");
+    expect(results.field).to.equal("title");
   });
 
-  it('parses example: java AND NOT yamaha', () => {
-    const results = lucene.parse('java AND NOT yamaha');
+  it("parses example: java AND NOT yamaha", () => {
+    const results = lucene.parse("java AND NOT yamaha");
 
-    expect(results.left.field).to.equal('<implicit>');
-    expect(results.left.term).to.equal('java');
-    expect(results.operator).to.equal('AND');
-    expect(results.right.operator).to.equal('NOT');
-    expect(results.right.left.field).to.equal('<implicit>');
-    expect(results.right.left.term).to.equal('yamaha');
+    expect(results.left.field).to.equal("<implicit>");
+    expect(results.left.term).to.equal("java");
+    expect(results.operator).to.equal("AND");
+    expect(results.right.operator).to.equal("NOT");
+    expect(results.right.left.field).to.equal("<implicit>");
+    expect(results.right.left.term).to.equal("yamaha");
   });
 
-  it('parses example: NOT (java OR python) AND android', () => {
-    const results = lucene.parse('NOT (java OR python) AND android');
+  it("parses example: NOT (java OR python) AND android", () => {
+    const results = lucene.parse("NOT (java OR python) AND android");
     const leftNode = results.left;
 
     // expect(results.start).to.equal('NOT');
 
-    expect(leftNode.left.left.field).to.equal('<implicit>');
-    expect(leftNode.left.left.term).to.equal('java');
-    expect(leftNode.operator).to.equal('NOT');
-    expect(leftNode.left.operator).to.equal('OR');
-    expect(leftNode.left.right.field).to.equal('<implicit>');
-    expect(leftNode.left.right.term).to.equal('python');
+    expect(leftNode.left.left.field).to.equal("<implicit>");
+    expect(leftNode.left.left.term).to.equal("java");
+    expect(leftNode.operator).to.equal("NOT");
+    expect(leftNode.left.operator).to.equal("OR");
+    expect(leftNode.left.right.field).to.equal("<implicit>");
+    expect(leftNode.left.right.term).to.equal("python");
 
-    expect(results.operator).to.equal('AND');
-    expect(results.right.field).to.equal('<implicit>');
-    expect(results.right.term).to.equal('android');
+    expect(results.operator).to.equal("AND");
+    expect(results.right.field).to.equal("<implicit>");
+    expect(results.right.term).to.equal("android");
   });
 
-  it('must handle whitespace in parens', () => {
-    const result = lucene.parse('foo ( bar OR baz)');
+  it("must handle whitespace in parens", () => {
+    const result = lucene.parse("foo ( bar OR baz)");
 
-    expect(result.left.field).to.equal('<implicit>');
-    expect(result.left.term).to.equal('foo');
-    expect(result.operator).to.equal('<implicit>');
-    expect(result.right.left.term).to.equal('bar');
-    expect(result.right.operator).to.equal('OR');
-    expect(result.right.right.term).to.equal('baz');
+    expect(result.left.field).to.equal("<implicit>");
+    expect(result.left.term).to.equal("foo");
+    expect(result.operator).to.equal("<implicit>");
+    expect(result.right.left.term).to.equal("bar");
+    expect(result.right.operator).to.equal("OR");
+    expect(result.right.right.term).to.equal("baz");
   });
 });

--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -1,208 +1,210 @@
-'use strict';
+"use strict";
 
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
-const lucene = require('../');
+const lucene = require("../");
 
-describe('toString', () => {
-  describe('Basic functionality', () => {
-    it('must handle empty ast', () => {
-      testAst(null, '');
-      testAst(undefined, '');
-      testAst(null, '');
+describe("toString", () => {
+  describe("Basic functionality", () => {
+    it("must handle empty ast", () => {
+      testAst(null, "");
+      testAst(undefined, "");
+      testAst(null, "");
     });
 
-    it('must handle simple terms', () => {
-      testStr('bar');
+    it("must handle simple terms", () => {
+      testStr("bar");
     });
 
-    it('must handle simple terms with explicit field name', () => {
-      testStr('foo:bar');
+    it("must handle simple terms with explicit field name", () => {
+      testStr("foo:bar");
     });
 
-    it('must handle simple terms with explicit field name in round parentheses', () => {
-      testStr('foo:(bar)');
+    it("must handle simple terms with explicit field name in round parentheses", () => {
+      testStr("foo:(bar)");
     });
 
-    it('must handle quoted terms', () => {
+    it("must handle quoted terms", () => {
       testStr('"fizz buz"');
     });
 
-    it('must handle empty quoted terms', () => {
+    it("must handle empty quoted terms", () => {
       testStr('""');
     });
 
-    it('must support field groups', () => {
-      testStr('foo:(bar OR baz)');
+    it("must support field groups", () => {
+      testStr("foo:(bar OR baz)");
     });
 
-    it('must support fuzzy', () => {
-      testStr('foo~0.6');
+    it("must support fuzzy", () => {
+      testStr("foo~0.6");
     });
 
-    it('must support fuzzy without explicit similarity', () => {
-      testStr('foo~');
+    it("must support fuzzy without explicit similarity", () => {
+      testStr("foo~");
     });
 
-    it('must drop default similarity value', () => {
-      testStr('foo~0.5', 'foo~');
+    it("must drop default similarity value", () => {
+      testStr("foo~0.5", "foo~");
     });
 
-    it('must support terms with \'-\'', () => {
-      testStr('created_at:>now-5d');
+    it("must support terms with '-'", () => {
+      testStr("created_at:>now-5d");
     });
 
-    it('must support terms with \'+\'', () => {
-      testStr('created_at:now+5d');
+    it("must support terms with '+'", () => {
+      testStr("created_at:now+5d");
     });
 
-    it('must support single-sided ranges with \'+\'', () => {
-      testStr('created_at:>now+5d');
+    it("must support single-sided ranges with '+'", () => {
+      testStr("created_at:>now+5d");
     });
 
-    it('must support regex terms', () => {
-      testStr('/^fizz b?u[A-z]/');
+    it("must support regex terms", () => {
+      testStr("/^fizz b?u[A-z]/");
     });
 
-    it('must support keyed regex terms', () => {
-      testStr('some.key:/[mh]otel/');
+    it("must support keyed regex terms", () => {
+      testStr("some.key:/[mh]otel/");
     });
 
-    it('must support prefix operators (-)', () => {
-      testStr('-bar');
+    it("must support prefix operators (-)", () => {
+      testStr("-bar");
     });
 
-    it('must support prefix operators (+)', () => {
-      testStr('+bar');
+    it("must support prefix operators (+)", () => {
+      testStr("+bar");
     });
 
-    it('must support prefix operators (-) on quoted terms', () => {
+    it("must support prefix operators (-) on quoted terms", () => {
       testStr('-"fizz buzz"');
     });
 
-    it('must support prefix operators (+) on quoted terms', () => {
+    it("must support prefix operators (+) on quoted terms", () => {
       testStr('+"fizz buzz"');
     });
 
-    it('must support dates as terms', () => {
-      testStr('foo:2015-01-01');
+    it("must support dates as terms", () => {
+      testStr("foo:2015-01-01");
     });
 
-    it('must support dots in field names', () => {
-      testStr('sub.foo:bar');
+    it("must support dots in field names", () => {
+      testStr("sub.foo:bar");
     });
 
-    it('must support quoted string with explicit field names', () => {
+    it("must support quoted string with explicit field names", () => {
       testStr('foo:"fizz buzz"');
     });
 
-    it('must support empty quoted string with explicit field names', () => {
+    it("must support empty quoted string with explicit field names", () => {
       testStr('foo:""');
     });
 
-    it('must support prefixes and explicit field names (-)', () => {
-      testStr('-foo:bar');
+    it("must support prefixes and explicit field names (-)", () => {
+      testStr("-foo:bar");
     });
 
-    it('must support prefixes and explicit field names in round parentheses (-)', () => {
-      testStr('foo:(-bar)');
+    it("must support prefixes and explicit field names in round parentheses (-)", () => {
+      testStr("foo:(-bar)");
     });
 
-    it('must support prefixes and explicit field names (+)', () => {
-      testStr('+foo:bar');
+    it("must support prefixes and explicit field names (+)", () => {
+      testStr("+foo:bar");
     });
 
-    it('must support prefixes and explicit field names in round parentheses (+)', () => {
-      testStr('foo:(+bar)');
+    it("must support prefixes and explicit field names in round parentheses (+)", () => {
+      testStr("foo:(+bar)");
     });
 
-    it('must support quoted prefixes', () => {
+    it("must support quoted prefixes", () => {
       testStr('-foo:"fizz buzz"');
     });
 
-    it('must support implicit conjunction operators', () => {
-      testStr('fizz buzz');
+    it("must support implicit conjunction operators", () => {
+      testStr("fizz buzz");
     });
 
-    it('must support explicit conjunction operators (OR)', () => {
-      testStr('fizz OR buzz');
+    it("must support explicit conjunction operators (OR)", () => {
+      testStr("fizz OR buzz");
     });
 
-    it('must support explicit conjunction operators (AND)', () => {
-      testStr('fizz AND buzz');
+    it("must support explicit conjunction operators (AND)", () => {
+      testStr("fizz AND buzz");
     });
 
-    it('must support explicit conjunction operators (NOT)', () => {
-      testStr('fizz NOT buzz');
+    it("must support explicit conjunction operators (NOT)", () => {
+      testStr("fizz NOT buzz");
     });
 
-    it('must support explicit conjunction operators (&&)', () => {
-      testStr('fizz && buzz');
+    it("must support explicit conjunction operators (&&)", () => {
+      testStr("fizz && buzz");
     });
 
-    it('must support explicit conjunction operators (||)', () => {
-      testStr('fizz || buzz');
+    it("must support explicit conjunction operators (||)", () => {
+      testStr("fizz || buzz");
     });
 
-    it('must support parentheses groups', () => {
-      testStr('fizz (buzz baz)');
+    it("must support parentheses groups", () => {
+      testStr("fizz (buzz baz)");
     });
 
-    it('must support parentheses groups with explicit conjunction operators', () => {
-      testStr('fizz AND (buzz OR baz)');
+    it("must support parentheses groups with explicit conjunction operators", () => {
+      testStr("fizz AND (buzz OR baz)");
     });
 
-    it('must support inclusive range expressions', () => {
-      testStr('foo:[bar TO baz]');
+    it("must support inclusive range expressions", () => {
+      testStr("foo:[bar TO baz]");
     });
 
-    it('must support exclusive range expressions', () => {
-      testStr('foo:{bar TO baz}');
+    it("must support exclusive range expressions", () => {
+      testStr("foo:{bar TO baz}");
     });
 
-    it('must support mixed range expressions (left inclusive)', () => {
-      testStr('foo:[bar TO baz}');
+    it("must support mixed range expressions (left inclusive)", () => {
+      testStr("foo:[bar TO baz}");
     });
 
-    it('must support mixed range expressions (right inclusive)', () => {
-      testStr('foo:{bar TO baz]');
+    it("must support mixed range expressions (right inclusive)", () => {
+      testStr("foo:{bar TO baz]");
     });
 
-    it('must support mixed range expressions (right inclusive) with date ISO format', () => {
-      testStr('date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]');
+    it("must support mixed range expressions (right inclusive) with date ISO format", () => {
+      testStr("date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]");
     });
 
-    it('must support strings with quotes', () => {
+    it("must support strings with quotes", () => {
       testStr('foo:"start \\" end"');
     });
 
-    it('must support escaped characters', () => {
-      testStr('foo\\(\\)\\{\\}\\+\\~\\!\\?\\[\\]\\:\\*bar');
+    it("must support escaped characters", () => {
+      testStr("foo\\(\\)\\{\\}\\+\\~\\!\\?\\[\\]\\:\\*bar");
     });
 
-    it('must support escaped whitespace', () => {
-      testStr('foo:a\\ b');
+    it("must support escaped whitespace", () => {
+      testStr("foo:a\\ b");
     });
 
-    it('must support whitespace in parens', () => {
-      testStr('foo ( bar OR baz)', 'foo (bar OR baz)');
+    it("must support whitespace in parens", () => {
+      testStr("foo ( bar OR baz)", "foo (bar OR baz)");
     });
 
-    it('must support ! prefix operator', () => {
-      testStr('-author:adams');
+    it("must support ! prefix operator", () => {
+      testStr("-author:adams");
     });
 
-    it('must support parenthesized expressions with start set', () => {
-      testStr('prop:value1 AND (NOT _exists_:other OR other:value2)');
+    it("must support parenthesized expressions with start set", () => {
+      testStr("prop:value1 AND (NOT _exists_:other OR other:value2)");
     });
 
-    it('must support parenthesized expressions with start set and not', () => {
-      testStr('prop:value1 AND (NOT _exists_:other OR other:value2)', 'prop:value1 AND (NOT _exists_:other OR other:value2)');
+    it("must support parenthesized expressions with start set and not", () => {
+      testStr(
+        "prop:value1 AND (NOT _exists_:other OR other:value2)",
+        "prop:value1 AND (NOT _exists_:other OR other:value2)"
+      );
     });
   });
 
-
-  describe('Lucene syntax examples', () => {
+  describe("Lucene syntax examples", () => {
     it('must support lucene example: title:"The Right Way" AND text:go', () => {
       testStr('title:"The Right Way" AND text:go');
     });
@@ -211,48 +213,48 @@ describe('toString', () => {
       testStr('title:"Do it right" AND right');
     });
 
-    it('must support lucene example: title:Do it right', () => {
-      testStr('title:Do it right');
+    it("must support lucene example: title:Do it right", () => {
+      testStr("title:Do it right");
     });
 
-    it('must support lucene example: te?t', () => {
-      testStr('te?t');
+    it("must support lucene example: te?t", () => {
+      testStr("te?t");
     });
 
-    it('must support lucene example: test*', () => {
-      testStr('test*');
+    it("must support lucene example: test*", () => {
+      testStr("test*");
     });
 
-    it('must support lucene example: te*t', () => {
-      testStr('te*t');
+    it("must support lucene example: te*t", () => {
+      testStr("te*t");
     });
 
-    it('must support lucene example: roam~', () => {
-      testStr('roam~');
+    it("must support lucene example: roam~", () => {
+      testStr("roam~");
     });
 
-    it('must support lucene example: roam~0.8', () => {
-      testStr('roam~0.8');
+    it("must support lucene example: roam~0.8", () => {
+      testStr("roam~0.8");
     });
 
     it('must support lucene example: "jakarta apache"~10', () => {
       testStr('"jakarta apache"~10');
     });
 
-    it('must support lucene example: mod_date:[20020101 TO 20030101]', () => {
-      testStr('mod_date:[20020101 TO 20030101]');
+    it("must support lucene example: mod_date:[20020101 TO 20030101]", () => {
+      testStr("mod_date:[20020101 TO 20030101]");
     });
 
-    it('must support lucene example: title:{Aida TO Carmen}', () => {
-      testStr('title:{Aida TO Carmen}');
+    it("must support lucene example: title:{Aida TO Carmen}", () => {
+      testStr("title:{Aida TO Carmen}");
     });
 
-    it('must support lucene example: jakarta apache', () => {
-      testStr('jakarta apache');
+    it("must support lucene example: jakarta apache", () => {
+      testStr("jakarta apache");
     });
 
-    it('must support lucene example: jakarta^4 apache', () => {
-      testStr('jakarta^4 apache');
+    it("must support lucene example: jakarta^4 apache", () => {
+      testStr("jakarta^4 apache");
     });
 
     it('must support lucene example: "jakarta apache"^4 "Apache Lucene"', () => {
@@ -271,8 +273,8 @@ describe('toString', () => {
       testStr('"jakarta apache" AND "Apache Lucene"');
     });
 
-    it('must support lucene example: +jakarta lucene', () => {
-      testStr('+jakarta lucene');
+    it("must support lucene example: +jakarta lucene", () => {
+      testStr("+jakarta lucene");
     });
 
     it('must support lucene example: "jakarta apache" NOT "Apache Lucene"', () => {
@@ -287,8 +289,8 @@ describe('toString', () => {
       testStr('"jakarta apache" -"Apache Lucene"');
     });
 
-    it('must support lucene example: (jakarta OR apache) AND website', () => {
-      testStr('(jakarta OR apache) AND website');
+    it("must support lucene example: (jakarta OR apache) AND website", () => {
+      testStr("(jakarta OR apache) AND website");
     });
 
     it('must support lucene example: title:(+return +"pink panther")', () => {
@@ -296,7 +298,10 @@ describe('toString', () => {
     });
   });
   function testAst(ast, expected) {
-    expect(lucene.toString(ast)).to.equal(expected, 'Got the following AST: ' + JSON.stringify(ast, 0, 2));
+    expect(lucene.toString(ast)).to.equal(
+      expected,
+      "Got the following AST: " + JSON.stringify(ast, 0, 2)
+    );
   }
 
   function testStr(str, expected) {


### PR DESCRIPTION
## Operator Precedence 
The operator precedence is now:

1. `NOT`/`!`
2. `AND`/`&&`
3. `OR`/`||`

Where 1 has the tightest binding, and 3 has the lowest. Terms separated
by an implicit operator `a b` will be treated similarly as an `OR` with
a *slightly* lower precedence.

The AST tests needed tweaked a bit to shift order around. The AST itself
can be cleaned up a fair bit from here, but this was a big enough
change.

## Backslash in Phrases
If the backslash is not used with a reserved character for escaping, it will be treated as a standard character. This allows searching for terms with the slash in the name.